### PR TITLE
[feat] 구글 소셜로그인 리팩토링 & 애플 소셜로그인 서비스코드 추가

### DIFF
--- a/teamplan/Sources/App/TeamPlanApp.swift
+++ b/teamplan/Sources/App/TeamPlanApp.swift
@@ -47,26 +47,11 @@ struct TeamPlanApp: App {
     //====================
     private func initializeApp() {
         configureFirebase()
-        restorePreviousGoogleSignIn()
+        //restorePreviousGoogleSignIn()
     }
     
     private func configureFirebase(){
         FirebaseApp.configure()
-    }
-
-    private func restorePreviousGoogleSignIn() {
-        GIDSignIn.sharedInstance.restorePreviousSignIn { restoreUser, error in
-            if let user = restoreUser {
-                authViewModel.state = .signedIn(AuthenticatedUser(user: user))
-                print("Previous login info recovered.")
-            } else if let error = error {
-                authViewModel.state = .signedOut
-                print("Error restoring previous login: \(error)")
-            } else {
-                authViewModel.state = .signedOut
-                print("No previous login data.")
-            }
-        }
     }
 
     private func handelOpenURL(_ url: URL){

--- a/teamplan/Sources/Archive/AuthenticationManager.swift
+++ b/teamplan/Sources/Archive/AuthenticationManager.swift
@@ -4,7 +4,7 @@
 //
 //  Created by sungyeon kim on 2023/06/01.
 //  Copyright © 2023 team1os. All rights reserved.
-//
+/*
 
 import Foundation
 import FirebaseAuth
@@ -84,3 +84,5 @@ extension AuthenticationManager {
         return AuthenticatedUser(user: authResult.user)
     }
 }
+ 
+*/

--- a/teamplan/Sources/Archive/AuthenticationModel.swift
+++ b/teamplan/Sources/Archive/AuthenticationModel.swift
@@ -4,7 +4,7 @@
 //
 //  Created by 주찬혁 on 2023/07/04.
 //  Copyright © 2023 team1os. All rights reserved.
-//
+/*
 
 import Foundation
 import FirebaseAuth
@@ -50,3 +50,5 @@ struct AuthenticatedUser{
         self.photoUrl = user.photoURL?.absoluteString
     }
 }
+
+*/

--- a/teamplan/Sources/Archive/Authenticator.swift
+++ b/teamplan/Sources/Archive/Authenticator.swift
@@ -89,5 +89,21 @@ final class Authenticator: NSObject, ObservableObject {
             self.signOut()
         }
     }
+    
+    // 구글로그인 이전상태 복구함수
+    private func restorePreviousGoogleSignIn() {
+        GIDSignIn.sharedInstance.restorePreviousSignIn { restoreUser, error in
+            if let user = restoreUser {
+                authViewModel.state = .signedIn(AuthenticatedUser(user: user))
+                print("Previous login info recovered.")
+            } else if let error = error {
+                authViewModel.state = .signedOut
+                print("Error restoring previous login: \(error)")
+            } else {
+                authViewModel.state = .signedOut
+                print("No previous login data.")
+            }
+        }
+    }
 }
 */

--- a/teamplan/Sources/Archive/GoogleLoginService.swift
+++ b/teamplan/Sources/Archive/GoogleLoginService.swift
@@ -4,7 +4,7 @@
 //
 //  Created by sungyeon kim on 2023/06/01.
 //  Copyright © 2023 team1os. All rights reserved.
-//
+/*
 
 import Foundation
 import GoogleSignIn
@@ -38,3 +38,5 @@ final class GoogleLoginService {
         return tokens
     }
 }
+
+*/

--- a/teamplan/Sources/Object/Authentication/AuthDTO.swift
+++ b/teamplan/Sources/Object/Authentication/AuthDTO.swift
@@ -35,6 +35,15 @@ struct AuthSocialLoginResDTO{
         self.accessToken = loginResult.user.accessToken.tokenString
         self.status = status
     }
+    
+    // Apple Authentication: NewUser | ExistUser
+    init(loginResult: User, idToken: String, status: UserStatus){
+        self.provider = .apple
+        self.email = loginResult.email!
+        self.idToken = idToken
+        self.accessToken = ""
+        self.status = status
+    }
 }
 
 //============================

--- a/teamplan/Sources/Object/Authentication/AuthDTO.swift
+++ b/teamplan/Sources/Object/Authentication/AuthDTO.swift
@@ -11,40 +11,42 @@ import FirebaseAuth
 import GoogleSignIn
 
 //============================
-// MARK: Google Login
+// MARK: DTO
 //============================
-
-struct AuthGoogleLoginResDTO{
-    
-    // id
-    let uid: String
+struct AuthSocialLoginResDTO{
     
     // login info
     let email: String
+    let provider: Providers
     
     // Token
     let idToken: String
     let accessToken: String
     
     // status
-    let isAuth: Bool
+    var status: UserStatus
     
     // Constructor
-    // Login
-    init(loginResult: GIDSignInResult){
-        self.uid = ""
-        self.email = loginResult.user.profile?.email ?? "Unkown Email"
-        self.idToken = loginResult.user.idToken?.tokenString ?? "Unknown idToken"
+    // Google Authentication: NewUser | ExistUser
+    init(loginResult: GIDSignInResult, status: UserStatus){
+        self.provider = .google
+        self.email = loginResult.user.profile!.email
+        self.idToken = loginResult.user.idToken!.tokenString
         self.accessToken = loginResult.user.accessToken.tokenString
-        self.isAuth = false
+        self.status = status
     }
-    
-    // Authentication
-    init(authResult: User, loginResult: AuthGoogleLoginResDTO){
-        self.uid = authResult.uid
-        self.email = authResult.email ?? "Unkown Email"
-        self.idToken = loginResult.idToken
-        self.accessToken = loginResult.accessToken
-        self.isAuth = true
-    }
+}
+
+//============================
+// MARK: Enum
+//============================
+enum Providers{
+    case apple
+    case google
+}
+
+enum UserStatus{
+    case new
+    case exist
+    case unknown
 }

--- a/teamplan/Sources/Services/Authentication/AuthAppleServices.swift
+++ b/teamplan/Sources/Services/Authentication/AuthAppleServices.swift
@@ -1,0 +1,57 @@
+//
+//  AuthAppleServices.swift
+//  teamplan
+//
+//  Created by 주찬혁 on 2023/10/13.
+//  Copyright © 2023 team1os. All rights reserved.
+//
+
+import Foundation
+import FirebaseAuth
+import AuthenticationServices
+
+final class AuthAppleServices{
+    
+    private var nonceGen: String?
+    
+    init() {
+        self.nonceGen = AppleLoginSupport.shared.randomNonceString()
+    }
+    
+    //====================
+    // MARK: Login
+    //====================
+    func login(appleCredential: ASAuthorizationAppleIDCredential ,
+               completion: @escaping(Result<AuthSocialLoginResDTO, Error>) -> Void) async {
+        
+        // Get Random nonce for credential
+        guard let nonce = nonceGen else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Nonce is missing"])))
+            return
+        }
+        
+        // Check for Apple's ID Token in the auth result
+        guard let appleIDToken = appleCredential.identityToken else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unable to fetch identity token"])))
+            return
+        }
+        
+        // Convert token to string
+        guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unable to serialize token string from data"])))
+            return
+        }
+        
+        // Create Firebase credential using token string and nonce
+        let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
+        
+        do{
+            let authResult = try await Auth.auth().signIn(with: credential)
+            let userStatus = authResult.additionalUserInfo?.isNewUser == true ? UserStatus.new : UserStatus.exist
+            
+            completion(.success(AuthSocialLoginResDTO(loginResult: authResult.user, idToken: idTokenString, status: userStatus)))
+        } catch {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown error occurred"])))
+        }
+    }
+}

--- a/teamplan/Sources/Services/Authentication/AuthGoogleServices.swift
+++ b/teamplan/Sources/Services/Authentication/AuthGoogleServices.swift
@@ -13,7 +13,6 @@ import KeychainSwift
 
 final class AuthGoogleServices{
     
-    // 이 친구로 로직 변경하고 AuthenticationManager, GoogleLoginService deprecated 시키기
     static let shared = AuthGoogleServices()
     private var keychain = KeychainSwift()
     init(){}
@@ -21,37 +20,45 @@ final class AuthGoogleServices{
     //====================
     // MARK: Login
     //====================
-    func login(result: @escaping(Result<AuthGoogleLoginResDTO, Error>) -> Void) async {
+    func login(result: @escaping(Result<AuthSocialLoginResDTO, Error>) -> Void) async {
         
         do{
+            // Google Social Setting
             guard let topVC = await GoogleLoginHelper.shared.topViewController() else {
-                result(.failure(URLError(.cannotFindHost)))
-                return
+                throw URLError(.cannotFindHost)
             }
             
             // Google Social Login
             let googleLoginResult = try await GIDSignIn.sharedInstance.signIn(withPresenting: topVC)
-            let googleLoginUser = AuthGoogleLoginResDTO(loginResult: googleLoginResult)
             
-            // Token Authentication
-            do{
-                let authUser = try await tokenAuth(candidate: googleLoginUser)
-                return result(.success(authUser))
-            } catch let authError {
-                result(.failure(authError))
-            }
+            // Firebase Authorization
+            let authResult = try await firebaseAuth(loginResult: googleLoginResult)
+            return result(.success(AuthSocialLoginResDTO(loginResult: googleLoginResult, status: authResult)))
             
-        } catch let gidError {
-            result(.failure(gidError))
+            // Excpetion
+        } catch let GIDError as GIDSignInError {
+            result(.failure(GIDError))
+        } catch let FBError as FirebaseAuth.AuthErrorCode {
+            result(.failure(FBError))
+        } catch {
+            result(.failure(FirebaseAuth.AuthErrorCode.internalError as! Error))
         }
     }
     
-    @discardableResult
-    private func tokenAuth(candidate: AuthGoogleLoginResDTO) async throws -> AuthGoogleLoginResDTO {
-        let credential = GoogleAuthProvider.credential(withIDToken: candidate.idToken, accessToken: candidate.accessToken)
-        let authResult = try await Auth.auth().signIn(with: credential)
+    // Token Authorization & NewUser Check
+    private func firebaseAuth(loginResult: GIDSignInResult) async throws -> UserStatus {
         
-        return AuthGoogleLoginResDTO(authResult: authResult.user, loginResult: candidate)
+        let credential = GoogleAuthProvider.credential(
+            withIDToken: loginResult.user.idToken!.tokenString,
+            accessToken: loginResult.user.accessToken.tokenString
+        )
+        do{
+            let authResult = try await Auth.auth().signIn(with: credential)
+            return authResult.additionalUserInfo?.isNewUser == true ? UserStatus.new : UserStatus.exist
+        } catch {
+            print(FirebaseAuth.AuthErrorCode.internalError as! Error)
+            return UserStatus.unknown
+        }
     }
     
     

--- a/teamplan/Sources/Services/Authentication/AuthGoogleServices.swift
+++ b/teamplan/Sources/Services/Authentication/AuthGoogleServices.swift
@@ -24,7 +24,7 @@ final class AuthGoogleServices{
     func login(result: @escaping(Result<AuthGoogleLoginResDTO, Error>) -> Void) async {
         
         do{
-            guard let topVC = await Utilities.shared.topViewController() else {
+            guard let topVC = await GoogleLoginHelper.shared.topViewController() else {
                 result(.failure(URLError(.cannotFindHost)))
                 return
             }

--- a/teamplan/Sources/Services/Authentication/GoogleLoginService.swift
+++ b/teamplan/Sources/Services/Authentication/GoogleLoginService.swift
@@ -18,7 +18,7 @@ final class GoogleLoginService {
     
     @MainActor
     func signIn() async throws -> GoogleSignInUser {
-        guard let topVC = Utilities.shared.topViewController() else {
+        guard let topVC = GoogleLoginHelper.shared.topViewController() else {
             throw URLError(.cannotFindHost)
         }
         

--- a/teamplan/Sources/Services/LoginService.swift
+++ b/teamplan/Sources/Services/LoginService.swift
@@ -15,35 +15,32 @@ final class LoginService{
     //====================
     // MARK: GoogleLogin
     //====================
-    func googleLogin() async {
+    func loginGoogle(result: @escaping(Result<AuthSocialLoginResDTO, Error>) -> Void) async {
         
-        // Try Google Social Login
-        await google.login(){ result in
-            switch result{
-                
-            //Successfully lgoin & Authentication
-            case .success(let authUser):
-                
-                // TODO: return type
-                print(authUser)
-                
-            // Error Handling
+        await google.login(){ loginResult in
+            switch loginResult {
+            // Authentication Success: NewUser & Exist
+            case .success(let userInfo):
+                result(.success(userInfo))
+                break
+            // Authentication Failure: Unknown
             case .failure(let error):
                 print(error)
-                
-                // TODO: case1. missing TopViewController
-                // TODO: case2. firebase authentication error
-                // TODO: case3. Google Social Login error
+                break
             }
         }
+                
+    // TODO: case1. missing TopViewController
+    // TODO: case2. firebase authentication error
+    // TODO: case3. Google Social Login error
+
     }
     
     
     //====================
     // MARK: AppleLogin
     //====================
-    
-    func appleLogin(){
+    func loginApple(){
         // TODO: (optional) set appllogin function
     }
 }

--- a/teamplan/Sources/Services/LoginService.swift
+++ b/teamplan/Sources/Services/LoginService.swift
@@ -7,10 +7,12 @@
 //
 
 import Foundation
+import AuthenticationServices
 
 final class LoginService{
     
     let google = AuthGoogleServices()
+    let apple = AuthAppleServices()
     
     //====================
     // MARK: GoogleLogin
@@ -36,11 +38,28 @@ final class LoginService{
 
     }
     
-    
     //====================
     // MARK: AppleLogin
     //====================
-    func loginApple(){
-        // TODO: (optional) set appllogin function
+    func loginApple(
+        appleCredential: ASAuthorizationAppleIDCredential ,
+        result: @escaping(Result<AuthSocialLoginResDTO, Error>) -> Void) async {
+        
+        await apple.login(appleCredential: appleCredential){ loginResult in
+            switch loginResult {
+            // Authentication Success: NewUser & Exist
+            case .success(let userInfo):
+                result(.success(userInfo))
+                break
+            // Authentication Failure: print error
+            case .failure(let error):
+                print(error)
+                
+                // TODO: case2. firebase authentication error
+                // TODO: case3. Apple Social Login error
+                
+                break
+            }
+        }
     }
 }

--- a/teamplan/Sources/Util/AppleLoginHelper.swift
+++ b/teamplan/Sources/Util/AppleLoginHelper.swift
@@ -1,0 +1,47 @@
+//
+//  AppleLoginHelper.swift
+//  teamplan
+//
+//  Created by 주찬혁 on 2023/10/13.
+//  Copyright © 2023 team1os. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+
+final class AppleLoginSupport{
+    
+    static let shared = AppleLoginSupport()
+    private init(){}
+    
+    //===============================
+    // MARK: - Nonce RandomGenerator
+    //===============================
+    func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        
+        guard errorCode == errSecSuccess else {
+            fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+        }
+        
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        let nonce = randomBytes.map { byte in charset[Int(byte) % charset.count] }
+        
+        return String(nonce)
+    }
+
+    //===============================
+    // MARK: - Incrypt
+    //===============================
+    func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+}

--- a/teamplan/Sources/Util/GoogleLoginHelper.swift
+++ b/teamplan/Sources/Util/GoogleLoginHelper.swift
@@ -1,0 +1,43 @@
+//
+//  GoogleLoginHelper.swift
+//  teamplan
+//
+//  Created by 주찬혁 on 2023/10/13.
+//  Copyright © 2023 team1os. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+final class GoogleLoginHelper{
+    static let shared = GoogleLoginHelper()
+    private init(){}
+    
+    @MainActor
+    func topViewController(controller: UIViewController? = nil) -> UIViewController? {
+        
+        let controller = controller ?? primaryRootViewController()
+
+        if let navigationController = controller as? UINavigationController {
+            return topViewController(controller: navigationController.visibleViewController)
+        }
+        if let tabController = controller as? UITabBarController {
+            if let selected = tabController.selectedViewController {
+                return topViewController(controller: selected)
+            }
+        }
+        if let presented = controller?.presentedViewController {
+            return topViewController(controller: presented)
+        }
+        return controller
+    }
+    
+    func primaryRootViewController() -> UIViewController? {
+        // Get the first window scene
+        if let windowScene = UIApplication.shared.connectedScenes.first(where: { $0 is UIWindowScene }) as? UIWindowScene,
+           let window = windowScene.windows.first {
+            return window.rootViewController
+        }
+        return nil
+    }
+}

--- a/teamplan/Sources/Util/Utilities.swift
+++ b/teamplan/Sources/Util/Utilities.swift
@@ -7,29 +7,7 @@
 //
 
 import Foundation
-import UIKit
 
 final class Utilities {
     
-    static let shared = Utilities()
-    private init() { }
-    
-    @MainActor
-    func topViewController(controller: UIViewController? = nil) -> UIViewController? {
-        
-        let controller = controller ?? UIApplication.shared.keyWindow?.rootViewController
-        
-        if let navigationController = controller as? UINavigationController {
-            return topViewController(controller: navigationController.visibleViewController)
-        }
-        if let tabController = controller as? UITabBarController {
-            if let selected = tabController.selectedViewController {
-                return topViewController(controller: selected)
-            }
-        }
-        if let presented = controller?.presentedViewController {
-            return topViewController(controller: presented)
-        }
-        return controller
-    }
 }

--- a/teamplan/Sources/Views/Onboarding/IntroView.swift
+++ b/teamplan/Sources/Views/Onboarding/IntroView.swift
@@ -40,13 +40,16 @@ struct IntroView_Previews: PreviewProvider {
 extension IntroView {
     private func isLoggedIn() -> Bool {
         let keychain = KeychainSwift()
-//        let accessToken = keychain.get("accessToken")
+        return false
+        /* Lock for Social Login Test
+        let accessToken = keychain.get("accessToken")
         
         if let idToken = keychain.get("idToken"), !idToken.isEmpty {
             return true
         } else {
             return false
         }
+         */
     }
     
     private var tabView: some View {


### PR DESCRIPTION
## Key Changes
### 공통
  * 모든 소셜로그인 결과값 Return 구조체 'AuthSocialLoginResDTO' 로 통일
    * 신규회원인지 기존 회원인지 파악하는 Enum 타입존재
  * 'LoginService' 구글/애플 소셜로그인 기능코드 호출가능
    * @escaping(Result<DTO,Error>) 타입으로 'success/failure' 으로 return  

### 구글 소셜로그인
  * 이전 버젼의 소셜로그인 호출파트 제거: AuthenticationViewModel
  * 'LoginService'를 통해 소셜로그인 기능을 호출하는 방식으로 변경
 
### 애플 소셜로그인
  * 'ASAuthorizationAppleIDCredential' 타입을 받아 Firebaes에 등록 및 신규유저 확인로직 추가
  
  
## To Reviewers
* 자세한 내용은 Commit 메세지 확인 부탁드립니다 :)
