### PR TITLE
[feat] Add 'LoginLoadingService' and Etc

### DIFF
--- a/teamplan/Sources/Object/Authentication/AuthDTO.swift
+++ b/teamplan/Sources/Object/Authentication/AuthDTO.swift
@@ -24,32 +24,32 @@ struct AuthSocialLoginResDTO{
     let accessToken: String
     
     // status
-    var status: UserStatus
+    var status: UserType
     
     // Constructor
     // Google Authentication: NewUser | ExistUser
-    init(loginResult: GIDSignInResult, status: UserStatus){
+    init(loginResult: GIDSignInResult, userType: UserType){
         self.provider = .google
         self.email = loginResult.user.profile!.email
         self.idToken = loginResult.user.idToken!.tokenString
         self.accessToken = loginResult.user.accessToken.tokenString
-        self.status = status
+        self.status = userType
     }
     
     // Apple Authentication: NewUser | ExistUser
-    init(loginResult: User, idToken: String, status: UserStatus){
+    init(loginResult: User, idToken: String, userType: UserType){
         self.provider = .apple
         self.email = loginResult.email!
         self.idToken = idToken
         self.accessToken = ""
-        self.status = status
+        self.status = userType
     }
 }
 
 //============================
 // MARK: Enum
 //============================
-enum UserStatus: String{
+enum UserType: String{
     case new = "Normal: User User"
     case exist = "Normal: Exist User"
     case unknown = "Caution: Unknown User"

--- a/teamplan/Sources/Object/Authentication/AuthDTO.swift
+++ b/teamplan/Sources/Object/Authentication/AuthDTO.swift
@@ -49,13 +49,8 @@ struct AuthSocialLoginResDTO{
 //============================
 // MARK: Enum
 //============================
-enum Providers: String{
-    case apple = "Apple"
-    case google = "Google"
-}
-
-enum UserStatus{
-    case new
-    case exist
-    case unknown
+enum UserStatus: String{
+    case new = "Normal: User User"
+    case exist = "Normal: Exist User"
+    case unknown = "Caution: Unknown User"
 }

--- a/teamplan/Sources/Object/Log/AccessLog.swift
+++ b/teamplan/Sources/Object/Log/AccessLog.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+//============================
+// MARK: Entity
+//============================
 struct AccessLog{
     // id
     let log_user_id: String
@@ -15,13 +18,34 @@ struct AccessLog{
     // content
     var log_access: [Date]
     
-    // constructor
+    // Constructor
+    // : Signup
     init(identifier: String, signupDate: Date){
         self.log_user_id = identifier
         self.log_access = [signupDate]
     }
     
-    // func
+    // : Get (Coredata)
+    init(acclogEntity: AccessLogEntity) {
+        self.log_user_id = acclogEntity.log_user_id!
+        self.log_access = acclogEntity.log_access as! [Date]
+    }
+    
+    // : Get (Firestore)
+    init?(acclogData: [String : Any]){
+        guard let log_user_id = acclogData["log_user_id"] as? String,
+              let log_access = acclogData["log_access"] as? [Date]
+        else {
+            return nil
+        }
+        // Assigning values
+        self.log_user_id = log_user_id
+        self.log_access = log_access
+    }
+    
+    //============================
+    // MARK: Func
+    //============================
     func toDictionary() -> [String : Any] {
         return [
             "log_user_id" : self.log_user_id,

--- a/teamplan/Sources/Object/Statistics/StatisticsDTO.swift
+++ b/teamplan/Sources/Object/Statistics/StatisticsDTO.swift
@@ -1,0 +1,52 @@
+//
+//  StatisticsDTO.swift
+//  teamplan
+//
+//  Created by 주찬혁 on 2023/10/25.
+//  Copyright © 2023 team1os. All rights reserved.
+//
+
+import Foundation
+
+struct StatisticsDTO{
+    // id
+    let stat_user_id: String
+    
+    //content: Etc
+    var stat_term: Int
+    var stat_drop: Int
+    
+    //content: Project & Todo
+    var stat_proj_reg: Int
+    var stat_proj_fin: Int
+    var stat_proj_alert: Int
+    var stat_proj_ext: Int
+    var stat_todo_reg: Int
+    
+    //content: Challenge
+    var stat_chlg_step: [[Int : Int]]
+    var stat_mychlg: [Int : Int]
+    
+    // maintenance
+    var stat_upload_at: Date
+    
+    // Constructor
+    init(statObject: StatisticsObject) {
+        self.stat_user_id = statObject.stat_user_id
+        self.stat_term = statObject.stat_term
+        self.stat_drop = statObject.stat_drop
+        self.stat_proj_reg = statObject.stat_proj_reg
+        self.stat_proj_fin = statObject.stat_proj_fin
+        self.stat_proj_alert = statObject.stat_proj_alert
+        self.stat_proj_ext = statObject.stat_proj_ext
+        self.stat_todo_reg = statObject.stat_todo_reg
+        self.stat_chlg_step = statObject.stat_chlg_step
+        self.stat_mychlg = statObject.stat_mychlg
+        self.stat_upload_at = statObject.stat_upload_at
+    }
+    
+    // Func
+    mutating func updateServiceTerm(updatedTerm: Int){
+        self.stat_term = updatedTerm
+    }
+}

--- a/teamplan/Sources/Object/Statistics/StatisticsObject.swift
+++ b/teamplan/Sources/Object/Statistics/StatisticsObject.swift
@@ -30,7 +30,7 @@ struct StatisticsObject{
     // maintenance
     var stat_upload_at: Date
     
-    // Constructor
+    // Service Constructor
     // : Signup
     init(identifier: String, signupDate: Date){
         self.stat_user_id = identifier
@@ -52,7 +52,8 @@ struct StatisticsObject{
         self.stat_upload_at = signupDate
     }
     
-    // : CoreData
+    // Store Constructor
+    // : Get (CoreData)
     init(statEntity: StatisticsEntity) {
         self.stat_user_id = statEntity.stat_user_id ?? "Unknown"
         self.stat_term = Int(statEntity.stat_term)
@@ -65,6 +66,52 @@ struct StatisticsObject{
         self.stat_chlg_step = statEntity.stat_chlg_step as! [[Int : Int]]
         self.stat_mychlg = statEntity.stat_mychlg as! [Int : Int]
         self.stat_upload_at = statEntity.stat_upload_at ?? Date()
+    }
+    
+    // : Update (Coredata)
+    init(updatedStat: StatisticsDTO){
+        self.stat_user_id = updatedStat.stat_user_id
+        self.stat_term = updatedStat.stat_term
+        self.stat_drop = updatedStat.stat_drop
+        self.stat_proj_reg = updatedStat.stat_proj_reg
+        self.stat_proj_fin = updatedStat.stat_proj_fin
+        self.stat_proj_alert = updatedStat.stat_proj_alert
+        self.stat_proj_ext = updatedStat.stat_proj_ext
+        self.stat_todo_reg = updatedStat.stat_todo_reg
+        self.stat_chlg_step = updatedStat.stat_chlg_step
+        self.stat_mychlg = updatedStat.stat_mychlg
+        self.stat_upload_at = updatedStat.stat_upload_at
+    }
+    
+    // : Get (Firestore)
+    init?(statData: [String : Any]){
+        guard let stat_user_id = statData["stat_user_id"] as? String,
+              let stat_term = statData["stat_term"] as? Int,
+              let stat_drop = statData["stat_drop"] as? Int,
+              let stat_proj_reg = statData["stat_proj_reg"] as? Int,
+              let stat_proj_fin = statData["stat_proj_fin"] as? Int,
+              let stat_proj_alert = statData["stat_proj_alert"] as? Int,
+              let stat_proj_ext = statData["stat_proj_ext"] as? Int,
+              let stat_todo_reg = statData["stat_todo_reg"] as? Int,
+              let stat_chlg_step = statData["stat_chlg_step"] as? [[Int : Int]],
+              let stat_mychlg = statData["stat_mychlg"] as? [Int : Int],
+              let stat_upload_at = statData["stat_upload_at"] as? Date
+        else {
+            return nil
+        }
+        
+        // Assigning values
+        self.stat_user_id = stat_user_id
+        self.stat_term = stat_term
+        self.stat_drop = stat_drop
+        self.stat_proj_reg = stat_proj_reg
+        self.stat_proj_fin = stat_proj_fin
+        self.stat_proj_alert = stat_proj_alert
+        self.stat_proj_ext = stat_proj_ext
+        self.stat_todo_reg = stat_todo_reg
+        self.stat_chlg_step = stat_chlg_step
+        self.stat_mychlg = stat_mychlg
+        self.stat_upload_at = stat_upload_at
     }
     
     //============================

--- a/teamplan/Sources/Object/User/UserDTO.swift
+++ b/teamplan/Sources/Object/User/UserDTO.swift
@@ -9,6 +9,34 @@
 import Foundation
 
 //============================
+// MARK: After Auth
+//============================
+struct UserDTO{
+    // id
+    let user_id: String
+    
+    // content
+    let user_email: String
+    let user_name: String
+    
+    // status:
+    let user_social_type: Providers
+    let user_status: UserStatus
+    
+    // maintenance:
+    let user_updated_at: Date
+    
+    init(userObject: UserObject){
+        self.user_id = userObject.user_id
+        self.user_email = userObject.user_email
+        self.user_name = userObject.user_name
+        self.user_social_type = Providers(rawValue: userObject.user_social_type) ?? .unknown
+        self.user_status = UserStatus(rawValue: userObject.user_status) ?? .unknown
+        self.user_updated_at = userObject.user_updated_at
+    }
+}
+
+//============================
 // MARK: Signup/SignupLoading
 //============================
 /// Request DTO : View -> Service
@@ -37,7 +65,7 @@ struct UserSignupReqDTO{
     }
 }
 
-struct UserSignupInfoDTO{
+struct UserSignupResDTO{
     // info
     let accountName: String
     let provider: Providers

--- a/teamplan/Sources/Object/User/UserObject.swift
+++ b/teamplan/Sources/Object/User/UserObject.swift
@@ -39,7 +39,7 @@ struct UserObject{
         self.user_email = newUser.email
         self.user_name = newUser.nickName
         self.user_social_type = newUser.provider.rawValue
-        self.user_status = UserType.active.rawValue
+        self.user_status = UserStatus.active.rawValue
         self.user_created_at = signupDate
         self.user_login_at = signupDate
         self.user_updated_at = signupDate
@@ -85,7 +85,7 @@ struct UserObject{
     }
     
     // : Get Dummy
-    init(user_id: String, user_fb_id: String, user_email: String, user_name: String, user_social_type: String, user_status: UserType, user_created_at: Date, user_login_at: Date, user_updated_at: Date) {
+    init(user_id: String, user_fb_id: String, user_email: String, user_name: String, user_social_type: String, user_status: UserStatus, user_created_at: Date, user_login_at: Date, user_updated_at: Date) {
         self.user_id = user_id
         self.user_fb_id = user_fb_id
         self.user_email = user_email
@@ -122,7 +122,7 @@ struct UserObject{
 //============================
 // MARK: Enum
 //============================
-enum UserType: String{
+enum UserStatus: String{
     case active = "Normal: Active User"
     case dormant = "Noraml: Dormant User"
     case unknown = "Caution: Unknown User"

--- a/teamplan/Sources/Object/User/UserObject.swift
+++ b/teamplan/Sources/Object/User/UserObject.swift
@@ -32,8 +32,8 @@ struct UserObject{
     
     
     // Constructor
-    // : SignupService Constructor
-    init(newUser: UserSignupReqDTO, signupDate: Date){
+    // : SignupService
+    init(newUser: UserSignupReqDTO, signupDate: Date) {
         self.user_id = newUser.identifier
         self.user_fb_id = ""
         self.user_email = newUser.email
@@ -46,7 +46,7 @@ struct UserObject{
     }
     
     // : Get Coredata
-    init(userEntity: UserEntity){
+    init(userEntity: UserEntity) {
         self.user_id = userEntity.user_id ?? "Unknown"
         self.user_fb_id = userEntity.user_fb_id ?? "Unknown"
         self.user_email = userEntity.user_email ?? "Unknown"
@@ -56,6 +56,32 @@ struct UserObject{
         self.user_created_at = userEntity.user_created_at ?? Date()
         self.user_login_at = userEntity.user_login_at ?? Date()
         self.user_updated_at = userEntity.user_updated_at ?? Date()
+    }
+    
+    // : Get Firestore
+    init?(userData: [String : Any], docsId: String){
+        guard let user_id = userData["user_id"] as? String,
+              let user_email = userData["user_email"] as? String,
+              let user_name = userData["user_name"] as? String,
+              let user_social_type = userData["user_social_type"] as? String,
+              let user_status = userData["user_status"] as? String,
+              let user_created_at = userData["user_created_at"] as? Date,
+              let user_login_at = userData["user_login_at"] as? Date,
+              let user_updated_at = userData["user_updated_at"] as? Date
+        else {
+            return nil
+        }
+        
+        // Assigning values
+        self.user_id = user_id
+        self.user_fb_id = docsId
+        self.user_email = user_email
+        self.user_name = user_name
+        self.user_social_type = user_social_type
+        self.user_status = user_status
+        self.user_created_at = user_created_at
+        self.user_login_at = user_login_at
+        self.user_updated_at = user_updated_at
     }
     
     // : Get Dummy
@@ -91,19 +117,19 @@ struct UserObject{
             "user_updated_at" : self.user_updated_at
         ]
     }
-    
-    
-    //============================
-    // MARK: Enum
-    //============================
-    enum UserType: String{
-        case active = "Activated"
-        case dormant = "Dormanted"
-        case unknown = "Unknowned"
-    }
-    
 }
 
+//============================
+// MARK: Enum
+//============================
+enum UserType: String{
+    case active = "Normal: Active User"
+    case dormant = "Noraml: Dormant User"
+    case unknown = "Caution: Unknown User"
+}
 
-
-
+enum Providers: String{
+    case apple = "Apple"
+    case google = "Google"
+    case unknown = "Unknown Providers"
+}

--- a/teamplan/Sources/Services/Authentication/AuthAppleServices.swift
+++ b/teamplan/Sources/Services/Authentication/AuthAppleServices.swift
@@ -47,9 +47,9 @@ final class AuthAppleServices{
         
         do{
             let authResult = try await Auth.auth().signIn(with: credential)
-            let userStatus = authResult.additionalUserInfo?.isNewUser == true ? UserStatus.new : UserStatus.exist
+            let userType = authResult.additionalUserInfo?.isNewUser == true ? UserType.new : UserType.exist
             
-            completion(.success(AuthSocialLoginResDTO(loginResult: authResult.user, idToken: idTokenString, status: userStatus)))
+            completion(.success(AuthSocialLoginResDTO(loginResult: authResult.user, idToken: idTokenString, userType: userType)))
         } catch {
             completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown error occurred"])))
         }

--- a/teamplan/Sources/Services/Authentication/AuthGoogleServices.swift
+++ b/teamplan/Sources/Services/Authentication/AuthGoogleServices.swift
@@ -33,7 +33,7 @@ final class AuthGoogleServices{
             
             // Firebase Authorization
             let authResult = try await firebaseAuth(loginResult: googleLoginResult)
-            return result(.success(AuthSocialLoginResDTO(loginResult: googleLoginResult, status: authResult)))
+            return result(.success(AuthSocialLoginResDTO(loginResult: googleLoginResult, userType: authResult)))
             
             // Excpetion
         } catch let GIDError as GIDSignInError {
@@ -46,7 +46,7 @@ final class AuthGoogleServices{
     }
     
     // Token Authorization & NewUser Check
-    private func firebaseAuth(loginResult: GIDSignInResult) async throws -> UserStatus {
+    private func firebaseAuth(loginResult: GIDSignInResult) async throws -> UserType {
         
         let credential = GoogleAuthProvider.credential(
             withIDToken: loginResult.user.idToken!.tokenString,
@@ -54,10 +54,10 @@ final class AuthGoogleServices{
         )
         do{
             let authResult = try await Auth.auth().signIn(with: credential)
-            return authResult.additionalUserInfo?.isNewUser == true ? UserStatus.new : UserStatus.exist
+            return authResult.additionalUserInfo?.isNewUser == true ? UserType.new : UserType.exist
         } catch {
             print(FirebaseAuth.AuthErrorCode.internalError as! Error)
-            return UserStatus.unknown
+            return UserType.unknown
         }
     }
     

--- a/teamplan/Sources/Services/HomeService.swift
+++ b/teamplan/Sources/Services/HomeService.swift
@@ -27,7 +27,7 @@ final class HomeService {
     ///    * success : 'user_id' & 'user_name' return
     ///    * exception : filled error message in 'user_id' & 'user_name'
     func getUser(result: @escaping(Result<String, Error>) -> Void) {
-        userCD.getUserCoredata(identifier: self.identifier) { cdResult in
+        userCD.getUser(identifier: self.identifier) { cdResult in
             switch cdResult {
             case .success(let userInfo):
                 return result(.success(userInfo.user_name))

--- a/teamplan/Sources/Services/Log/AccessLogServicesFirestore.swift
+++ b/teamplan/Sources/Services/Log/AccessLogServicesFirestore.swift
@@ -26,7 +26,7 @@ final class AccessLogServicesFirestore{
         // Add AccessLog
         collectionRef.addDocument(data: reqLog.toDictionary()){ error in
             
-            // Exception Handling: Firestore
+            // Exception Handling: Internal Error (Firestore)
             if let error = error {
                 result(.failure(error))
                 
@@ -37,7 +37,124 @@ final class AccessLogServicesFirestore{
     }
     
     //================================
+    // MARK: - Get AccessLog
+    //================================
+    func getAccessLog(identifier: String,
+                      result: @escaping(Result<AccessLog, Error>) -> Void) {
+        
+        // Target Table
+        let collectionRef = fs.collection("AccessLog")
+        
+        // Search AccessLog
+        collectionRef.whereField("log_user_id", isEqualTo: identifier).getDocuments() { (snapShot, error) in
+            
+            // Exception Handling : Internal Error (FirestoreServer)
+            if let error = error {
+                return result(.failure(error))
+            }
+            
+            // Exception Handling : Docs Search Falied by Input Identifier
+            guard let response = snapShot else {
+                return result(.failure(StatFSError.StatRetrievalByIdentifierFailed))
+            }
+            
+            switch response.documents.count {
+            
+            // Successfully Get AccessLog from Firestore
+            case 1:
+                let docs = response.documents.first!
+                if let log = AccessLog(acclogData: docs.data()){
+                    return result(.success(log))
+                    
+                // Exception Handling : Failed to fetch AccessLog from Docs
+                } else {
+                    return result(.failure(AcclogFSError.UnexpectedFetchError))
+                }
+                
+            // Exception Handling : Multiple AccessLog Found
+            case let count where count > 1:
+                return result(.failure(AcclogFSError.MultipleAcclogFound))
+                
+            // Exception Handling : Internal Error (FetchDocument)
+            default:
+                return result(.failure(FirestoreErrorCode.internal as! Error))
+            }
+        }
+    }
+    
+    //================================
     // MARK: - Update AccessLog
     //================================
+    func updateAccessLog(identifier: String, updateAcclog: AccessLog,
+                         result: @escaping(Result<String, Error>) -> Void) {
+        
+        let updatedData: [String : Any] = [
+            "log_user_id" : updateAcclog.log_user_id,
+            "log_access" : updateAcclog.log_access
+        ]
+        
+        // Target Table
+        let collectionRef = fs.collection("AccessLog")
+        
+        // Search AccessLog
+        collectionRef.whereField("log_user_id", isEqualTo: identifier).getDocuments() { (snapShot, error) in
+            
+            // Exception Handling : Internal Error (FirestoreServer)
+            if let error = error {
+                return result(.failure(error))
+            }
+            
+            // Exception Handling : Docs Search Falied by Input Identifier
+            guard let response = snapShot else {
+                return result(.failure(StatFSError.StatRetrievalByIdentifierFailed))
+            }
+            
+            switch response.documents.count {
+            
+            // Successfully Get AccessLog from Firestore
+            case 1:
+                let docs = response.documents.first!
+                
+                // Update LogData
+                docs.reference.setData(updatedData) { error in
+                    if let error = error {
+                        return result(.failure(error))
+                    } else {
+                        return result(.success("Successfully Set AccessLog"))
+                    }
+                }
+                
+            // Exception Handling : Multiple AccessLog Found
+            case let count where count > 1:
+                return result(.failure(AcclogFSError.MultipleAcclogFound))
+                
+            // Exception Handling : Internal Error (FetchDocument)
+            default:
+                return result(.failure(AcclogFSError.InternalError))
+            }
+        }
+    }
+}
+
+//================================
+// MARK: - Exception
+//================================
+enum AcclogFSError: LocalizedError {
+    case StatRetrievalByIdentifierFailed
+    case UnexpectedFetchError
+    case MultipleAcclogFound
+    case InternalError
     
+    var errorDescription: String? {
+        switch self {
+        case .StatRetrievalByIdentifierFailed:
+            return "Firestore: Unable to retrieve 'AccessLog' data using the provided identifier."
+        case .UnexpectedFetchError:
+            return "Firestore: There was an unexpected error while fetching 'AccessLog' details"
+        case .MultipleAcclogFound:
+            return "Firestore: Multiple 'AccessLog' found. Expected only one."
+        case .InternalError:
+            return "Firestore: Internal Error Occurred"
+        }
+    }
 }

--- a/teamplan/Sources/Services/LoginLoadingService.swift
+++ b/teamplan/Sources/Services/LoginLoadingService.swift
@@ -1,0 +1,121 @@
+//
+//  LoginLoadingService.swift
+//  teamplan
+//
+//  Created by 주찬혁 on 2023/10/25.
+//  Copyright © 2023 team1os. All rights reserved.
+//
+
+import Foundation
+
+final class LoginLoadingService{
+    
+    let util = Utilities()
+    let userCD = UserServicesCoredata()
+    let userFS = UserServicesFirestore()
+    
+    //==============================
+    // MARK: Core Function
+    //==============================
+    // Step1. Get User
+    func getUser(authResult: AuthSocialLoginResDTO,
+                 result: @escaping(Result<UserDTO, Error>) -> Void) {
+        
+        // extract Identifer from LoginInfo
+        getIdentifier(authResult: authResult) { [weak self] response in
+            switch response {
+                
+                // Search Coredata
+            case .success(let identifier):
+                self?.fetchUser(identifier: identifier, result: result)
+                
+                // Exception Handling : Invalid Email Format
+            case .failure(let error):
+                return result(.failure(error))
+            }
+        }
+    }
+    // Step2. Get Statistics
+    
+    // Step3. Get AccessLog
+    
+    // Step4-1. Update Statistics (ServiceTerm)
+    
+    // Step4-2. Update AccessLog
+}
+
+//==============================
+// MARK: Get User
+//==============================
+extension LoginLoadingService{
+    
+    // Step1. Identifier
+    func getIdentifier(authResult: AuthSocialLoginResDTO,
+                       result: @escaping(Result<String, Error>) -> Void) {
+        util.getIdentifier(authRes: authResult, result: result)
+    }
+    
+    // Step2. Get User From Coredata or Firestore
+    func fetchUser(identifier: String,
+                   result: @escaping(Result<UserDTO, Error>) -> Void) {
+        
+        self.fetchUserFromCoredata(identifier: identifier) { [weak self] response in
+            switch response {
+                
+                // Successfully get UserInfo from CoreData
+            case .success(let userInfo):
+                return result(.success(UserDTO(userObject: userInfo)))
+                
+                // No userInfo at CoreData => Jump to Firestore
+            case .failure(let error as UserServiceCDError) where error == .UserRetrievalByIdentifierFailed:
+                self?.fetchUserFromFirestore(identifier: identifier, result: result)
+                
+                // ExceptionHandling : Internal Error (Coredata)
+            case .failure(let error):
+                return result(.failure(error))
+            }
+        }
+    }
+    
+    // Step3-1. Get from Coredata
+    private func fetchUserFromCoredata(identifier: String,
+                                       result: @escaping(Result<UserObject, Error>) -> Void) {
+        userCD.getUser(identifier: identifier, result: result)
+    }
+    
+    // Step3-2. (Option) Get from Firestore
+    private func fetchUserFromFirestore(identifier: String,
+                                        result: @escaping(Result<UserDTO, Error>) -> Void) {
+        
+        userFS.getUser(identifier: identifier) { [weak self] fsResponse in
+            switch fsResponse {
+                
+                // Successgully get UserInfo from Firestore
+            case .success(let userInfo):
+                
+                // Set userInfo to Coredata
+                self?.storeUserToCoredata(user: userInfo) { cdResponse in
+                    switch cdResponse {
+                    case .success(let msg):
+                        print(msg)
+                        return result(.success(UserDTO(userObject: userInfo)))
+                        
+                        // ExceptionHandling : Internal Error (Coredata)
+                    case .failure(let error):
+                        result(.failure(error))
+                    }
+                }
+                // No userInfo at Firestore
+                // 'UserFSError.IdentiferDocsGetError' case = newUser
+            case .failure(let error):
+                return result(.failure(error))
+            }
+        }
+    }
+    
+    // Step1-3. (Option) Store to Coredata
+    private func storeUserToCoredata(user: UserObject,
+                                     result: @escaping(Result<String, Error>) -> Void) {
+        userCD.setUser(userObject: user, result: result)
+    }
+}

--- a/teamplan/Sources/Services/SignupLoadingService.swift
+++ b/teamplan/Sources/Services/SignupLoadingService.swift
@@ -40,7 +40,7 @@ final class SignupLoadingService{
     //===============================
     // : Firestore
     func setUserFS(result: @escaping(Result<Bool, Error>) -> Void) {
-        userFS.setUserFirestore(reqUser: self.newProfile) { fsResult in
+        userFS.setUser(reqUser: self.newProfile) { fsResult in
             switch fsResult {
     
             case .success(let docsId):
@@ -56,7 +56,7 @@ final class SignupLoadingService{
     
     // : Coredata
     func setUserCD(result: @escaping(Result<Bool, Error>) -> Void) {
-        userCD.setUserCoredata(userObject: self.newProfile) { cdResult in
+        userCD.setUser(userObject: self.newProfile) { cdResult in
             self.handleServiceResult(cdResult, with: result)
         }
     }

--- a/teamplan/Sources/Services/SignupLoadingService.swift
+++ b/teamplan/Sources/Services/SignupLoadingService.swift
@@ -66,14 +66,14 @@ final class SignupLoadingService{
     //===============================
     // : Firestore
     func setStatisticsFS(result: @escaping(Result<Bool, Error>) -> Void) {
-        statFS.setStatisticsFS(reqStat: self.newStat) { fsResult in
+        statFS.setStatistics(reqStat: self.newStat) { fsResult in
             self.handleServiceResult(fsResult, with: result)
         }
     }
     
     // : Coredata
     func setStatisticsCD(result: @escaping(Result<Bool, Error>) -> Void) {
-        statCD.setStatCoredata(reqStat: self.newStat) { cdResult in
+        statCD.setStatistics(reqStat: self.newStat) { cdResult in
             self.handleServiceResult(cdResult, with: result)
         }
     }

--- a/teamplan/Sources/Services/SignupService.swift
+++ b/teamplan/Sources/Services/SignupService.swift
@@ -19,7 +19,7 @@ final class SignupService{
     // MARK: - Get AccountInfo
     //===============================
     func getAccountInfo(newUser: AuthSocialLoginResDTO,
-                        result: @escaping(Result<UserSignupInfoDTO, Error>) -> Void) {
+                        result: @escaping(Result<UserSignupResDTO, Error>) -> Void) {
         
         // extract AccountName from SocialLogin Result
         util.getAccountName(userEmail: newUser.email){ getAccResult in
@@ -33,7 +33,7 @@ final class SignupService{
                 self.userInfo = UserSignupReqDTO(identifier: identifier, email: newUser.email, provider: newUser.provider)
                 
                 // return UserInfo that require SignupView
-                return result(.success(UserSignupInfoDTO(accountName: accName, provider: newUser.provider)))
+                return result(.success(UserSignupResDTO(accountName: accName, provider: newUser.provider)))
                 
             // Exception Handling: Invalid Email Format
             case .failure(let error):

--- a/teamplan/Sources/Services/Statistics/StatisticsCenter.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsCenter.swift
@@ -24,7 +24,7 @@ final class StatisticsCenter{
     func returnUserProgress(challengeType: ChallengeType,
                             result: @escaping(Result<Int, Error>) -> Void) {
         
-        statCD.getStatCoredata(identifier: self.identifier) { getRes in
+        statCD.getStatistics(identifier: self.identifier) { getRes in
             switch getRes{
             case .success(let reqStat):
                 

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
@@ -22,7 +22,7 @@ final class StatisticsServicesCoredata{
     //================================
     // MARK: - Get Statistics
     //================================
-    func getStatCoredata(identifier: String,
+    func getStatistics(identifier: String,
                          result: @escaping(Result<StatisticsObject, Error>) -> Void) {
         
         // parameter setting
@@ -33,66 +33,106 @@ final class StatisticsServicesCoredata{
         fetchReq.fetchLimit = 1
         
         do{
-            let fetchStat = try context.fetch(fetchReq)
-            
-            // Exception Handling: Identifier
-            guard let reqStat = fetchStat.first else {
-                return result(.failure(StatCDError.IdentifierFetchFailed))
+            // Search Statistics
+            guard let statEntity = try context.fetch(fetchReq).first else {
+                return result(.failure(StatCDError.StatRetrievalByIdentifierFailed))
             }
-            return result(.success(StatisticsObject(statEntity: reqStat)))
+            return result(.success(StatisticsObject(statEntity: statEntity)))
         
             // Eception Handling: Unknown
         } catch  {
-            return result(.failure(StatCDError.GetFailed))
+            return result(.failure(StatCDError.UnexpectedGetError))
         }
     }
     
     //================================
     // MARK: - Set Statistics
     //================================
-    func setStatCoredata(reqStat: StatisticsObject,
+    func setStatistics(reqStat: StatisticsObject,
                          result: @escaping(Result<String, Error>) -> Void) {
         
         // Create New StatisticsEntity
-        let stat = StatisticsEntity(context: context)
+        let statEntity = StatisticsEntity(context: context)
         
-        stat.stat_user_id = reqStat.stat_user_id
-        stat.stat_term = Int32(reqStat.stat_term)
-        stat.stat_drop = Int32(reqStat.stat_drop)
-        stat.stat_proj_reg = Int32(reqStat.stat_proj_reg)
-        stat.stat_proj_fin = Int32(reqStat.stat_proj_fin)
-        stat.stat_proj_alert = Int32(reqStat.stat_proj_alert)
-        stat.stat_proj_ext = Int32(reqStat.stat_proj_ext)
-        stat.stat_todo_reg = Int32(reqStat.stat_todo_reg)
-        stat.stat_chlg_step = reqStat.stat_chlg_step as NSObject
-        stat.stat_mychlg = reqStat.stat_mychlg as NSObject
-        stat.stat_upload_at = reqStat.stat_upload_at
+        statEntity.stat_user_id = reqStat.stat_user_id
+        statEntity.stat_term = Int32(reqStat.stat_term)
+        statEntity.stat_drop = Int32(reqStat.stat_drop)
+        statEntity.stat_proj_reg = Int32(reqStat.stat_proj_reg)
+        statEntity.stat_proj_fin = Int32(reqStat.stat_proj_fin)
+        statEntity.stat_proj_alert = Int32(reqStat.stat_proj_alert)
+        statEntity.stat_proj_ext = Int32(reqStat.stat_proj_ext)
+        statEntity.stat_todo_reg = Int32(reqStat.stat_todo_reg)
+        statEntity.stat_chlg_step = reqStat.stat_chlg_step as NSObject
+        statEntity.stat_mychlg = reqStat.stat_mychlg as NSObject
+        statEntity.stat_upload_at = reqStat.stat_upload_at
 
         do{
             try context.save()
             return result(.success("Successfully set Statistics at CoreData"))
         } catch {
-            return result(.failure(StatCDError.SetFailed))
+            return result(.failure(StatCDError.UnexpectedSetError))
         }
     }
     
-    //===============================
-    // MARK: - Exception
-    //===============================
-    enum StatCDError: LocalizedError {
-        case IdentifierFetchFailed
-        case SetFailed
-        case GetFailed
+    //================================
+    // MARK: - Update Statistics
+    //================================
+    func updateStatistics(identifier: String, updatedStatInfo: StatisticsDTO,
+                          result: @escaping(Result<String, Error>) -> Void) {
         
-        var errorDescription: String?{
-            switch self {
-            case .IdentifierFetchFailed:
-                return "Failed to Fetch Statistics by identifier"
-            case .SetFailed:
-                return "Failed to Set Statistics at CoreData"
-            case .GetFailed:
-                return "Failed to Get Statistics for Unknown reason"
+        // parameter setting
+        let fetchReq: NSFetchRequest<StatisticsEntity> = StatisticsEntity.fetchRequest()
+        
+        // Request Query
+        fetchReq.predicate = NSPredicate(format: "stat_user_id == %@", identifier)
+        fetchReq.fetchLimit = 1
+        
+        do {
+            guard let statEntity = try self.context.fetch(fetchReq).first else {
+                throw StatCDError.StatRetrievalByIdentifierFailed
             }
+            
+            // Update StatisticsEntity
+            statEntity.stat_term = Int32(updatedStatInfo.stat_term)
+            statEntity.stat_drop = Int32(updatedStatInfo.stat_drop)
+            statEntity.stat_proj_reg = Int32(updatedStatInfo.stat_proj_reg)
+            statEntity.stat_proj_fin = Int32(updatedStatInfo.stat_proj_fin)
+            statEntity.stat_proj_alert = Int32(updatedStatInfo.stat_proj_alert)
+            statEntity.stat_proj_ext = Int32(updatedStatInfo.stat_proj_ext)
+            statEntity.stat_todo_reg = Int32(updatedStatInfo.stat_todo_reg)
+            statEntity.stat_chlg_step = updatedStatInfo.stat_chlg_step as NSObject
+            statEntity.stat_mychlg = updatedStatInfo.stat_mychlg as NSObject
+            statEntity.stat_upload_at = updatedStatInfo.stat_upload_at
+            try context.save()
+            
+            return result(.success("Successfully Update Statistics at CoreData"))
+            
+        // Eception Handling: Internal Error
+        } catch {
+            return result(.failure(StatCDError.UnexpectedUpdateError))
+        }
+    }
+}
+
+//===============================
+// MARK: - Exception
+//===============================
+enum StatCDError: LocalizedError {
+    case StatRetrievalByIdentifierFailed
+    case UnexpectedSetError
+    case UnexpectedGetError
+    case UnexpectedUpdateError
+    
+    var errorDescription: String?{
+        switch self {
+        case .StatRetrievalByIdentifierFailed:
+            return "Coredata: Unable to retrieve 'Statistics' data using the provided identifier."
+        case .UnexpectedSetError:
+            return "Coredata: There was an unexpected error while Set 'Statistics' details"
+        case .UnexpectedGetError:
+            return "Coredata: There was an unexpected error while Get 'Statistics' details"
+        case .UnexpectedUpdateError:
+            return "Coredata: There was an unexpected error while Update 'Statistics' details"
         }
     }
 }

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesFirestore.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesFirestore.swift
@@ -17,7 +17,7 @@ final class StatisticsServicesFirestore{
     //================================
     // MARK: - Set Statistics
     //================================
-    func setStatisticsFS(reqStat: StatisticsObject,
+    func setStatistics(reqStat: StatisticsObject,
                          result: @escaping(Result<String, Error>) -> Void) {
         
         // Target Table
@@ -26,7 +26,7 @@ final class StatisticsServicesFirestore{
         // Add Statistics
         collectionRef.addDocument(data: reqStat.toDictionary()){ error in
             
-            // Exception Handling: Firestore
+            // Exception Handling: Internal Error (FirestoreServer)
             if let error = error {
                 result(.failure(error))
             } else {
@@ -36,7 +36,118 @@ final class StatisticsServicesFirestore{
     }
     
     //================================
+    // MARK: - Get Statistics
+    //================================
+    func getStatistics(identifier: String,
+                       result: @escaping(Result<StatisticsObject, Error>) -> Void) {
+        
+        // Target Table
+        let collectionRef = fs.collection("Stat")
+        
+        // Search Statistics
+        collectionRef.whereField("stat_user_id", isEqualTo: identifier).getDocuments() { (snapShot, error) in
+            
+            // Exception Handling : Internal Error (FirestoreServer)
+            if let error = error {
+                return result(.failure(error))
+            }
+            
+            // Exception Handling : Docs Search Falied by Input Identifier
+            guard let response = snapShot else {
+                return result(.failure(StatFSError.StatRetrievalByIdentifierFailed))
+            }
+            
+            switch response.documents.count {
+                
+            // Successfully Get Statistics from Firestore
+            case 1:
+                let docs = response.documents.first!
+                if let stat = StatisticsObject(statData: docs.data()) {
+                    return result(.success(stat))
+                    
+                // Exception Handling : Failed to fetch Statistics from Docs
+                } else {
+                    return result(.failure(StatFSError.UnexpectedGetError))
+                }
+                
+            // Exception Handling : Multiple User Found
+            case let count where count > 1:
+                return result(.failure(StatFSError.MultipleStatFound))
+                
+            // Exception Handling : Internal Error (FetchDocument)
+            default:
+                return result(.failure(FirestoreErrorCode.internal as! Error))
+            }
+        }
+    }
+    
+    //================================
     // MARK: - Update Statistics
     //================================
+    func updateStatistics(identifier: String, updatedStatInfo: StatisticsDTO,
+                          result: @escaping(Result<String, Error>) -> Void) {
+        
+        let updatedData = StatisticsObject(updatedStat: updatedStatInfo)
+        
+        // Target Table
+        let collectionRef = fs.collection("Stat")
+        
+        // Search Statistics
+        collectionRef.whereField("stat_user_id", isEqualTo: identifier).getDocuments() { (snapShot, error) in
+            
+            // Exception Handling : Internal Error (FirestoreServer)
+            if let error = error {
+                return result(.failure(error))
+            }
+            
+            // Exception Handling : Docs Search Falied by Input Identifier
+            guard let response = snapShot else {
+                return result(.failure(StatFSError.StatRetrievalByIdentifierFailed))
+            }
+            
+            switch response.documents.count {
+                
+            // Successfully Get Statistics from Firestore
+            case 1:
+                let docs = response.documents.first!
+                
+                // Update Statistics
+                docs.reference.setData(updatedData.toDictionary()) { error in
+                    if let error = error {
+                        return result(.failure(error))
+                    } else {
+                        return result(.success("Successfully Update Statistics"))
+                    }
+                }
+                
+            // Exception Handling : Multiple User Found
+            case let count where count > 1:
+                return result(.failure(StatFSError.MultipleStatFound))
+                
+            // Exception Handling : Internal Error (FetchDocument)
+            default:
+                return result(.failure(FirestoreErrorCode.internal as! Error))
+            }
+        }
+    }
+}
+
+//================================
+// MARK: - Exception
+//================================
+enum StatFSError: LocalizedError {
+    case UnexpectedGetError
+    case StatRetrievalByIdentifierFailed
+    case MultipleStatFound
     
+    var errorDescription: String? {
+        switch self {
+        case .UnexpectedGetError:
+            return "Firestore: There was an unexpected error while Get 'Statistics' details"
+        case .StatRetrievalByIdentifierFailed:
+            return "Firestore: Unable to retrieve 'Statistics' data using the provided identifier."
+        case .MultipleStatFound:
+            return "Firestore: Multiple 'Statistics' found. Expected only one."
+        }
+    }
 }

--- a/teamplan/Sources/Services/User/UserServicesCoredata.swift
+++ b/teamplan/Sources/Services/User/UserServicesCoredata.swift
@@ -22,7 +22,7 @@ final class UserServicesCoredata{
     //================================
     // MARK: - Get User
     //================================
-    func getUserCoredata(identifier: String,
+    func getUser(identifier: String,
                          result: @escaping(Result<UserObject, Error>) -> Void) {
         
         // parameter setting
@@ -33,24 +33,22 @@ final class UserServicesCoredata{
         fetchReq.fetchLimit = 1
         
         do{
-            let fetchUser = try context.fetch(fetchReq)
-            
             // Exception Handling: Identifier
-            guard let reqUser = fetchUser.first else {
-                return result(.failure(UserServiceCDError.IdentifierFetchFailed))
+            guard let userEntity = try context.fetch(fetchReq).first else {
+                return result(.failure(UserServiceCDError.UserRetrievalByIdentifierFailed))
             }
-            return result(.success(UserObject(userEntity: reqUser)))
+            return result(.success(UserObject(userEntity: userEntity)))
             
-            // Eception Handling: Unknown
+        // Eception Handling: Internal Error (Coredata)
         } catch {
-            return result(.failure(UserServiceCDError.GetFailed))
+            return result(.failure(UserServiceCDError.UnexpectedGetError))
         }
     }
     
     //================================
     // MARK: - Set User
     //================================
-    func setUserCoredata(userObject: UserObject,
+    func setUser(userObject: UserObject,
                          result: @escaping(Result<String, Error>) -> Void) {
         
         // Create New UserEntity
@@ -70,7 +68,7 @@ final class UserServicesCoredata{
             try context.save()
             return result(.success("Successfully set User Data at CoreData"))
         } catch {
-            return result(.failure(UserServiceCDError.SetFailed))
+            return result(.failure(UserServiceCDError.UnexpectedSetError))
         }
     }
     
@@ -82,25 +80,24 @@ final class UserServicesCoredata{
     //================================
     // MARK: - Delete User
     //================================
+}
+
+//===============================
+// MARK: - Exception
+//===============================
+enum UserServiceCDError: LocalizedError {
+    case UserRetrievalByIdentifierFailed
+    case UnexpectedSetError
+    case UnexpectedGetError
     
-    
-    //===============================
-    // MARK: - Exception
-    //===============================
-    enum UserServiceCDError: LocalizedError {
-        case IdentifierFetchFailed
-        case SetFailed
-        case GetFailed
-        
-        var errorDescription: String?{
-            switch self {
-            case .IdentifierFetchFailed:
-                return "Failed to Fetch User by identifier"
-            case .SetFailed:
-                return "Failed to Set User Data at CoreData"
-            case .GetFailed:
-                return "Failed to Get User for Unknown reason"
-            }
+    var errorDescription: String?{
+        switch self {
+        case .UserRetrievalByIdentifierFailed:
+            return "CoreData: Unable to retrieve 'User' data using the provided identifier."
+        case .UnexpectedSetError:
+            return "Coredata: There was an unexpected error while Set 'User' details"
+        case .UnexpectedGetError:
+            return "Coredata: There was an unexpected error while Get 'User' details"
         }
     }
 }

--- a/teamplan/Sources/Util/Utilities.swift
+++ b/teamplan/Sources/Util/Utilities.swift
@@ -52,4 +52,23 @@ final class Utilities {
             }
         }
     }
+    
+    //============================
+    // MARK: Time Calculation
+    //============================
+    func calcTime(currentTime: Date, lastTime: Date) -> Bool {
+        
+        let calendar = Calendar.current
+        let lastTimeComp = calendar.dateComponents([.year, .month, .day], from: lastTime)
+        let currentTimeComp = calendar.dateComponents([.year, .month, .day], from: currentTime)
+        
+        if let lastTimeDay = calendar.date(from: lastTimeComp),
+           let currentTimeDay = calendar.date(from: currentTimeComp),
+           
+            currentTimeDay <= lastTimeDay {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/teamplan/Sources/Util/Utilities.swift
+++ b/teamplan/Sources/Util/Utilities.swift
@@ -10,9 +10,30 @@ import Foundation
 
 final class Utilities {
     
-    //====================
-    // MARK: Identifier
-    //====================
+    //============================
+    // MARK: Get Identifier
+    //============================
+    func getIdentifier(authRes: AuthSocialLoginResDTO,
+                       result: @escaping(Result<String, Error>) -> Void) {
+        
+        self.getAccountName(userEmail: authRes.email) { res in
+            switch res {
+                
+            // create identifier
+            case .success(let nickName):
+                let identifier = "\(nickName)_\(authRes.provider.rawValue)"
+                return result(.success(identifier))
+                
+            // Exception Handling: Invalid Email Format
+            case .failure(let error):
+                return result(.failure(error))
+            }
+        }
+    }
+    
+    //============================
+    // MARK: Extract AccountName
+    //============================
     func getAccountName(userEmail: String,
                         result: @escaping(Result<String, Error>) -> Void) {
         guard let atIndex = userEmail.firstIndex(of: "@"), atIndex != userEmail.startIndex else {


### PR DESCRIPTION
## Key Changes
* **'User' / 'Statistics' / 'AccessLog' 스토리지 관련코드 리팩토링**
* **'LoginLoadingService' 추가**
  * 저장소(Coredata/Firestore) 에서 유저정보, 통계정보, 접속기록 추출
  * 로컬저장소(Coredata)에 없는경우 원격저장소(Firestore)에서 탐색
  * 통계정보 및 접속기록의 경우, 로그인에 따른 데이터변동 후 저장소 업데이트 진행
  
## To Reviewers
자세한 내용은 Commit 메세지 확인 부탁드립니다 :)
