### PR TITLE
[fix] Modify Firestore 'Get' function

### DIFF
--- a/teamplan/Sources/Object/Log/AccessLog.swift
+++ b/teamplan/Sources/Object/Log/AccessLog.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import FirebaseFirestore
 
 //============================
 // MARK: Entity
@@ -32,24 +33,38 @@ struct AccessLog{
     }
     
     // : Get (Firestore)
-    init?(acclogData: [String : Any]){
+    init?(acclogData: [String : Any]) {
         guard let log_user_id = acclogData["log_user_id"] as? String,
-              let log_access = acclogData["log_access"] as? [Date]
+              let log_access_string = acclogData["log_access"] as? [String]
         else {
             return nil
         }
+        // Date Converter
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        
+        let logDates = log_access_string.compactMap { formatter.date(from: $0) }
+        guard logDates.count == log_access_string.count else {
+            return nil
+        }
+        
         // Assigning values
         self.log_user_id = log_user_id
-        self.log_access = log_access
+        self.log_access = logDates
     }
     
     //============================
     // MARK: Func
     //============================
     func toDictionary() -> [String : Any] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        
+        let logStrings = self.log_access.map { formatter.string(from: $0) }
+        
         return [
             "log_user_id" : self.log_user_id,
-            "log_access" : self.log_access
+            "log_access" : logStrings
         ]
     }
 }

--- a/teamplan/Sources/Object/Log/ChallengeLog.swift
+++ b/teamplan/Sources/Object/Log/ChallengeLog.swift
@@ -17,18 +17,52 @@ struct ChallengeLog{
     let log_update_at: Date
     
     // constructor
+    // : SignupService
     init(identifier: String, signupDate: Date){
         self.log_user_id = identifier
         self.log_complete = [:]
         self.log_update_at = signupDate
     }
     
-    // func
+    init?(challengeData: [String : Any]) {
+        guard let log_user_id = challengeData["log_user_id"] as? String,
+              let log_complete_string = challengeData["log_complete"] as? [Int : String],
+              let log_update_at_string = challengeData["log_update_at"] as? String
+        else {
+            return nil
+        }
+        // Date Converter
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        
+        var log_complete: [Int: Date] = [:]
+        for (key, dateString) in log_complete_string {
+            log_complete[key] = formatter.date(from: dateString)
+        }
+        guard let log_update_at = formatter.date(from: log_update_at_string) else {
+                return nil
+        }
+        
+        // Assigning values
+        self.log_user_id = log_user_id
+        self.log_complete = log_complete
+        self.log_update_at = log_update_at
+    }
+    
+    //============================
+    // MARK: Func
+    //============================
     func toDictionary() -> [String : Any] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        
+        let logCompleteStrings = self.log_complete.mapValues { formatter.string(from: $0) }
+        let logUpdateStrings = formatter.string(from: self.log_update_at)
+        
         return [
             "log_user_id" : self.log_user_id,
-            "log_complete" : self.log_complete,
-            "log_update_at" : self.log_update_at
+            "log_complete" : logCompleteStrings,
+            "log_update_at" : logUpdateStrings
         ]
     }
 }

--- a/teamplan/Sources/Object/Statistics/StatisticsObject.swift
+++ b/teamplan/Sources/Object/Statistics/StatisticsObject.swift
@@ -95,10 +95,13 @@ struct StatisticsObject{
               let stat_todo_reg = statData["stat_todo_reg"] as? Int,
               let stat_chlg_step = statData["stat_chlg_step"] as? [[Int : Int]],
               let stat_mychlg = statData["stat_mychlg"] as? [Int : Int],
-              let stat_upload_at = statData["stat_upload_at"] as? Date
+              let stat_upload_at = statData["stat_upload_at"] as? String
         else {
             return nil
         }
+        // Date Converter
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
         
         // Assigning values
         self.stat_user_id = stat_user_id
@@ -111,13 +114,16 @@ struct StatisticsObject{
         self.stat_todo_reg = stat_todo_reg
         self.stat_chlg_step = stat_chlg_step
         self.stat_mychlg = stat_mychlg
-        self.stat_upload_at = stat_upload_at
+        self.stat_upload_at = formatter.date(from: stat_upload_at)!
     }
     
     //============================
     // MARK: Func
     //============================
     func toDictionary() -> [String : Any] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        
         return [
             "stat_user_id": self.stat_user_id,
             "stat_term": self.stat_term,
@@ -129,7 +135,7 @@ struct StatisticsObject{
             "stat_todo_reg": self.stat_todo_reg,
             "stat_chlg_step": self.stat_chlg_step,
             "stat_mychlg": self.stat_mychlg,
-            "stat_upload_at": self.stat_upload_at
+            "stat_upload_at": formatter.string(from: self.stat_upload_at)
         ]
     }
 }

--- a/teamplan/Sources/Object/User/UserObject.swift
+++ b/teamplan/Sources/Object/User/UserObject.swift
@@ -30,7 +30,6 @@ struct UserObject{
     var user_updated_at: Date
     
     
-    
     // Constructor
     // : SignupService
     init(newUser: UserSignupReqDTO, signupDate: Date) {
@@ -59,18 +58,21 @@ struct UserObject{
     }
     
     // : Get Firestore
-    init?(userData: [String : Any], docsId: String){
+    init?(userData: [String : Any], docsId: String) {
         guard let user_id = userData["user_id"] as? String,
               let user_email = userData["user_email"] as? String,
               let user_name = userData["user_name"] as? String,
               let user_social_type = userData["user_social_type"] as? String,
               let user_status = userData["user_status"] as? String,
-              let user_created_at = userData["user_created_at"] as? Date,
-              let user_login_at = userData["user_login_at"] as? Date,
-              let user_updated_at = userData["user_updated_at"] as? Date
+              let user_created_at = userData["user_created_at"] as? String,
+              let user_login_at = userData["user_login_at"] as? String,
+              let user_updated_at = userData["user_updated_at"] as? String
         else {
             return nil
         }
+        // Date Converter
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
         
         // Assigning values
         self.user_id = user_id
@@ -79,9 +81,9 @@ struct UserObject{
         self.user_name = user_name
         self.user_social_type = user_social_type
         self.user_status = user_status
-        self.user_created_at = user_created_at
-        self.user_login_at = user_login_at
-        self.user_updated_at = user_updated_at
+        self.user_created_at = formatter.date(from: user_created_at)!
+        self.user_login_at = formatter.date(from: user_login_at)!
+        self.user_updated_at = formatter.date(from: user_updated_at)!
     }
     
     // : Get Dummy
@@ -106,15 +108,18 @@ struct UserObject{
     }
     
     func toDictionary() -> [String: Any] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        
         return [
             "user_id" : self.user_id,
             "user_email" : self.user_email,
             "user_name" : self.user_name,
             "user_social_type" : self.user_social_type,
             "user_status" : self.user_status,
-            "user_created_at" : self.user_created_at,
-            "user_login_at" : self.user_login_at,
-            "user_updated_at" : self.user_updated_at
+            "user_created_at" : formatter.string(from: self.user_created_at),
+            "user_login_at" : formatter.string(from: self.user_login_at),
+            "user_updated_at" : formatter.string(from: self.user_updated_at)
         ]
     }
 }

--- a/teamplan/Sources/Services/Log/AccessLogServicesFirestore.swift
+++ b/teamplan/Sources/Services/Log/AccessLogServicesFirestore.swift
@@ -63,13 +63,12 @@ final class AccessLogServicesFirestore{
             // Successfully Get AccessLog from Firestore
             case 1:
                 let docs = response.documents.first!
-                if let log = AccessLog(acclogData: docs.data()){
-                    return result(.success(log))
+                guard let log = AccessLog(acclogData: docs.data()) else {
                     
-                // Exception Handling : Failed to fetch AccessLog from Docs
-                } else {
+                    // Exception Handling : Failed to fetch AccessLog from Docs
                     return result(.failure(AcclogFSError.UnexpectedFetchError))
                 }
+                return result(.success(log))
                 
             // Exception Handling : Multiple AccessLog Found
             case let count where count > 1:

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesFirestore.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesFirestore.swift
@@ -62,13 +62,12 @@ final class StatisticsServicesFirestore{
             // Successfully Get Statistics from Firestore
             case 1:
                 let docs = response.documents.first!
-                if let stat = StatisticsObject(statData: docs.data()) {
-                    return result(.success(stat))
+                guard let stat = StatisticsObject(statData: docs.data()) else {
                     
-                // Exception Handling : Failed to fetch Statistics from Docs
-                } else {
-                    return result(.failure(StatFSError.UnexpectedGetError))
+                    // Exception Handling : Failed to fetch Statistics from Docs
+                    return result(.failure(StatFSError.UnexpectedConvertError))
                 }
+                return result(.success(stat))
                 
             // Exception Handling : Multiple User Found
             case let count where count > 1:
@@ -137,6 +136,7 @@ final class StatisticsServicesFirestore{
 //================================
 enum StatFSError: LocalizedError {
     case UnexpectedGetError
+    case UnexpectedConvertError
     case StatRetrievalByIdentifierFailed
     case MultipleStatFound
     
@@ -144,6 +144,8 @@ enum StatFSError: LocalizedError {
         switch self {
         case .UnexpectedGetError:
             return "Firestore: There was an unexpected error while Get 'Statistics' details"
+        case .UnexpectedConvertError:
+            return "Firestore: There was an unexpected error while Convert 'Statistics' details"
         case .StatRetrievalByIdentifierFailed:
             return "Firestore: Unable to retrieve 'Statistics' data using the provided identifier."
         case .MultipleStatFound:

--- a/teamplan/Sources/Services/User/UserServicesFirestore.swift
+++ b/teamplan/Sources/Services/User/UserServicesFirestore.swift
@@ -50,10 +50,12 @@ final class UserServicesFirestore{
         // Search User
         collectionRef.whereField("user_id", isEqualTo: identifier).getDocuments() { (snapShot, error) in
             
+            // Exception Handling: Internal Error (FirestoreServer)
             if let error = error {
                 return result(.failure(error))
             }
             
+            // Exception Handling: Identifier
             guard let response = snapShot else {
                 return result(.failure(UserFSError.UserRetrievalByIdentifierFailed))
             }
@@ -62,13 +64,18 @@ final class UserServicesFirestore{
                 
             case 1:
                 let docs = response.documents.first!
-                if let user = UserObject(userData: docs.data(), docsId: docs.documentID) {
-                    return result(.success(user))
+                guard let user = UserObject(userData: docs.data(), docsId: docs.documentID) else {
+                    
+                    // Exception Handling: Converting Error
+                    return result(.failure(UserFSError.UnexpectedConvertError))
                 }
+                return result(.success(user))
                 
+            // Exception Handling: Multiple User Found
             case let count where count > 1:
                 return result(.failure(UserFSError.MultipleUserFound))
-                
+               
+            // Exception Handling: Internal Error (FirestoreClient)
             default:
                 return result(.failure(UserFSError.InternalError))
             }
@@ -82,6 +89,7 @@ final class UserServicesFirestore{
 enum UserFSError: LocalizedError {
     case UnexpectedSetError
     case UnexpectedGetError
+    case UnexpectedConvertError
     case UserRetrievalByIdentifierFailed
     case MultipleUserFound
     case InternalError
@@ -92,6 +100,8 @@ enum UserFSError: LocalizedError {
             return "Firestore: There was an unexpected error while Set 'User' details"
         case .UnexpectedGetError:
             return "Firestore: There was an unexpected error while Get 'User' details"
+        case .UnexpectedConvertError:
+            return "Firestore: There was an unexpected error while Convert 'User' details"
         case .UserRetrievalByIdentifierFailed:
             return "Firestore: Unable to retrieve 'User' data using the provided identifier."
         case .MultipleUserFound:


### PR DESCRIPTION
## Key Changes
'LoginLoadingService' 의 'getUser' 테스트 중, Firestore에 저장된 데이터를 제대로 가져오지 못하는 현상을 확인하였습니다

해당 문제를 고치기 위한 수정사항입니다.

적용후 팀계정 기반의 identifier로 Firestore에 저장된 유저정보를 가져오고 Coredata에 저장을 성공하는 것을 확인하였습니다.
  
## To Reviewers
자세한 내용은 commit 메세지 확인 부탁드립니다
