### PR TITLE
[Fix] Refact 'Statistics' related

### DIFF
--- a/teamplan/Sources/Object/Statistics/StatisticsDTO.swift
+++ b/teamplan/Sources/Object/Statistics/StatisticsDTO.swift
@@ -25,7 +25,7 @@ struct StatisticsDTO{
     
     //content: Challenge
     var stat_chlg_step: [[Int : Int]]
-    var stat_mychlg: [Int : Int]
+    var stat_mychlg: [Int]
     
     // maintenance
     var stat_upload_at: Date

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
@@ -119,7 +119,7 @@ final class StatisticsServicesCoredata{
         do {
             // Convert JSON String Data
             let chlgStep = try util.convertFromJSON(jsonString: reqStat.stat_chlg_step, type: [[Int : Int]].self)
-            let myChlg = try util.convertFromJSON(jsonString: reqStat.stat_mychlg, type: [Int : Int].self)
+            let myChlg = try util.convertFromJSON(jsonString: reqStat.stat_mychlg, type: [Int].self)
             
             // Struct Oject
             guard let stat = StatisticsObject(statEntity: reqStat, chlgStep: chlgStep, mychlg: myChlg) else {

--- a/teamplan/Sources/Util/Utilities.swift
+++ b/teamplan/Sources/Util/Utilities.swift
@@ -120,6 +120,19 @@ final class Utilities {
     }
 }
 
+//============================
+// MARK: Dictionary Extension
+//============================
+extension Dictionary {
+    func mapKeys<T: Hashable>(_ transform: (Key) -> T) -> [T: Value] {
+        var newDict = [T: Value]()
+        for (key, value) in self {
+            newDict[transform(key)] = value
+        }
+        return newDict
+    }
+}
+
 //================================
 // MARK: - Exception
 //================================


### PR DESCRIPTION
## Key Changes
* Object
  * 'stat_mychlg' 데이터타입을 딕셔너리 타입([Int : Int])에서 배열([Int])로 변경
  * 기존 JSONString으로 변경하는 부분에서 'stat_mychlg' 제외
  * 'stat_chlg_step' 의 Firestore 저장 및 추출 서포트함수 재구성
* DTO/Service
  * 데이터 타입변경에 수정
* Utilities
  * Dictionary 데이터타입 변경에 필요한 extension 추가 * key 데이터타입을 String으로 전환하는 기능추가

  
## To Reviewers
setStatistics 함수수행 결과 Firestore에 정상적으로 저장되는것을 확인하였습니다!
