### PR TITLE
[refact][fix] Apple & Google Social Login Logic

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -27,6 +27,7 @@ let project = Project(
             infoPlist: "teamplan/Info.plist",
             sources: ["teamplan/Sources/**"],
             resources: ["teamplan/Resources/**"],
+            entitlements: "teamplan/teamplan.entitlements",
             scripts: [
                 .pre(script: "${PROJECT_DIR}/teamplan/Tools/swiftgen config run --config \"${PROJECT_DIR}/teamplan/Resources/swiftgen.yml\"", name: "Gen")
             ],

--- a/teamplan/Sources/Object/UserObject.swift
+++ b/teamplan/Sources/Object/UserObject.swift
@@ -15,8 +15,8 @@ enum UserStatus: String{
 }
 
 enum Providers: String{
-    case apple = "Apple"
-    case google = "Google"
+    case apple = "apple.com"
+    case google = "google.com"
     case unknown = "Unknown Providers"
 }
 

--- a/teamplan/Sources/Protocol/ServiceError.swift
+++ b/teamplan/Sources/Protocol/ServiceError.swift
@@ -16,8 +16,9 @@ enum ErrorLocation: String {
     case coredata = "Coredata"
     case firestore = "Firestore"
     case google = "GoogleSocialLogin"
+    case apple = "AppleSocialLogin"
     case signup = "Signup"
-    case login = "LoginLoading"
+    case login = "Login Loading"
 }
 
 enum ServiceType: String {
@@ -29,6 +30,7 @@ enum ServiceType: String {
     case todo = "todo"
     case log = "AccessLog"
     case googleLogin = "GoogleSocialLogin"
+    case appleLogin = "AppleSocialLogin"
     case signup = "SignupLoading"
     case login = "LoginLoading"
 }
@@ -68,6 +70,28 @@ enum FirestoreError: ServiceErrorProtocol {
     
     var errorLocation: ErrorLocation {
         return .firestore
+    }
+    
+    var errorDescription: String {
+        return getErrorDescription(for: self)
+    }
+}
+
+// MARK: - Apple Social Login
+enum AppleSocialLoginError: ServiceErrorProtocol {
+    case invalidCredentials(serviceName: ServiceType)
+    case tokenCreationFailed(serviceName: ServiceType)
+    case signInFailed(serviceName: ServiceType)
+    
+    var serviceName: ServiceType {
+        switch self {
+        case .invalidCredentials(let serviceName), .tokenCreationFailed(let serviceName), .signInFailed(let serviceName):
+            return serviceName
+        }
+    }
+    
+    var errorLocation: ErrorLocation {
+        return .apple
     }
     
     var errorDescription: String {
@@ -154,6 +178,16 @@ func getErrorDescription(for error: ServiceErrorProtocol) -> String {
             return baseMessage + "to fetch '\(serviceName.rawValue)' document."
         case .convertFailure(let serviceName):
             return baseMessage + "to convert '\(serviceName.rawValue)' document to object."
+        }
+        
+    case let error as AppleSocialLoginError:
+        switch error {
+        case .invalidCredentials(let serviceName):
+            return baseMessage + "to get valid credentials"
+        case .tokenCreationFailed(let serviceName):
+            return baseMessage + "to create AuthToken"
+        case .signInFailed(let serviceName):
+            return baseMessage + "to apple social login"
         }
         
     case let error as GoogleSocialLoginError:

--- a/teamplan/Sources/Services/LoginLoadingService.swift
+++ b/teamplan/Sources/Services/LoginLoadingService.swift
@@ -55,7 +55,7 @@ final class LoginLoadingService{
     func executor(with dto: AuthSocialLoginResDTO) async throws -> UserInfoDTO {
         
         self.loginDate = Date()
-        self.userId = try util.getIdentifier(from: dto)
+        self.userId = dto.identifier
         
         if !checkLocalData() {
             try await getUserDataFromServer()

--- a/teamplan/Sources/Services/LoginService.swift
+++ b/teamplan/Sources/Services/LoginService.swift
@@ -23,44 +23,61 @@ final class LoginService{
     }
     
     // MARK: - method
+    // Google Login
     func loginGoogle() async throws -> AuthSocialLoginResDTO {
         return try await google.login()
     }
     
-    func requestNonceSignInApple() -> String {
+    // Apple Login
+    func loginApple(appleAuthResult: ASAuthorization, nonce: String) async throws -> AuthSocialLoginResDTO {
+        return try await apple.login(loginResult: appleAuthResult, nonce: nonce)
+    }
+    
+    func requestNonce() -> String {
         return self.apple.randomNonce()
     }
+    
+    func reqeustNonceEncode(nonce: String) -> String {
+        return self.apple.sha256(nonce)
+    }
+    
+    // Local Login
 }
 
 // MARK: - AuthDTO
 struct AuthSocialLoginResDTO {
     
-    let email: String?
+    let identifier: String
+    let email: String
     let provider: Providers
-    let idToken: String?
+    let idToken: String
     let accessToken: String
     var status: UserType
     
-    // Google
-    init(loginResult: GIDSignInResult, userType: UserType){
-        self.provider = .google
-        self.email = loginResult.user.profile?.email
-        self.idToken = loginResult.user.idToken?.tokenString
-        self.accessToken = loginResult.user.accessToken.tokenString
-        self.status = userType
-    }
-    
-    // Apple
-    init(loginResult: User?, idToken: String, userType: UserType){
-        self.provider = .apple
-        self.email = loginResult?.email
+    init(identifier: String, email: String, provider: Providers, idToken: String, accessToken: String, status: UserType) {
+        self.identifier = identifier
+        self.email = email
+        self.provider = provider
         self.idToken = idToken
-        self.accessToken = ""
-        self.status = userType
+        self.accessToken = accessToken
+        self.status = status
     }
 }
 
-enum UserType: String{
-    case new = "New User"
-    case exist = "Exist User"
+// MARK: FirebaseAuthDTO
+struct FirebaseAuthRegistResultDTO {
+    let identifier: String
+    let email: String
+    let status: UserType
+    
+    init(identifier: String, email: String, status: UserType) {
+        self.identifier = identifier
+        self.email = email
+        self.status = status
+    }
+}
+
+enum UserType {
+    case new
+    case exist
 }

--- a/teamplan/Sources/Services/SignupService.swift
+++ b/teamplan/Sources/Services/SignupService.swift
@@ -14,7 +14,7 @@ final class SignupService{
     
     func getAccountInfo(newUser: AuthSocialLoginResDTO) throws -> UserSignupDTO {
         
-        return UserSignupDTO(with: try util.getIdentifier(from: newUser), and: newUser)
+        return UserSignupDTO(with: newUser)
     }
 }
 
@@ -26,9 +26,9 @@ struct UserSignupDTO{
     let logHead : Int
     var nickName: String
     
-    init(with userId: String, and dto: AuthSocialLoginResDTO) {
-        self.userId = userId
-        self.email = dto.email ?? ""
+    init(with dto: AuthSocialLoginResDTO) {
+        self.userId = dto.identifier
+        self.email = dto.email
         self.provider = dto.provider
         self.logHead = 1
         self.nickName = ""

--- a/teamplan/Sources/ViewModels/HomeViewModel.swift
+++ b/teamplan/Sources/ViewModels/HomeViewModel.swift
@@ -35,14 +35,12 @@ final class HomeViewModel: ObservableObject {
         homeService.challenge.$myChallenges
             .receive(on: DispatchQueue.main)
             .sink { [weak self] myChallenges in
-                print("myChallenges: \(myChallenges)")
                 self?.myChallenges = myChallenges
             }
             .store(in: &cancellables)
         
         homeService.challenge.$statDTO
             .sink { [weak self] statistics in
-                print("statistics: \(String(describing: statistics))")
                 self?.statistics = statistics
             }
             .store(in: &cancellables)

--- a/teamplan/Sources/ViewModels/SignupViewModel.swift
+++ b/teamplan/Sources/ViewModels/SignupViewModel.swift
@@ -12,21 +12,10 @@ import KeychainSwift
 
 final class SignupViewModel: ObservableObject {
     
-//    @Published var jobs: [SignupModel] = []
-//    @Published var interests: [SignupModel] = []
-//    @Published var abilities: [SignupModel] = []
-//
-//    @Published var selectedJobs: [String] = []
-//    @Published var selectedInterests: [String] = []
-//    @Published var selectedAbilities: [String] = []
-    
     @Published var nickName: String = ""
-    
     @Published var test = true
+    
     let signupUser: AuthSocialLoginResDTO
-    
-    
-//    private let signupDataService = SignupDataService()
     private var cancellables = Set<AnyCancellable>()
     
     init(signupUser: AuthSocialLoginResDTO) {
@@ -35,24 +24,6 @@ final class SignupViewModel: ObservableObject {
     }
     
     private func addSubscribers() {
-//        signupDataService.$jobs
-//            .sink { [weak self] jobs in
-//                self?.jobs = jobs
-//            }
-//            .store(in: &cancellables)
-//
-//        signupDataService.$interests
-//            .sink { [weak self] interests in
-//                self?.interests = interests
-//            }
-//            .store(in: &cancellables)
-//
-//        signupDataService.$abilities
-//            .sink { [weak self] abilities in
-//                self?.abilities = abilities
-//            }
-//            .store(in: &cancellables)
-//
         $nickName
             .sink { [weak self] name in
                 if name.count > 5 {
@@ -64,9 +35,4 @@ final class SignupViewModel: ObservableObject {
             }
             .store(in: &cancellables)
     }
-    
-    func trySignup(newUser: UserSignupDTO) {
-        
-    }
-    
 }

--- a/teamplan/Sources/ViewModels/TermsViewModel.swift
+++ b/teamplan/Sources/ViewModels/TermsViewModel.swift
@@ -47,8 +47,6 @@ final class TermsViewModel: ObservableObject {
                 self?.wholeTermsButton = allAgree
             }
             .store(in: &cancellables)
-        
-        
     }
     
     func didTapAllAgreeButton() {
@@ -62,8 +60,6 @@ final class TermsViewModel: ObservableObject {
         
         self.isAgree = wholeTermsButton?.isSelected == true ? true : false
         self.requiredTermsCount = wholeTermsButton?.isSelected == true ? 2 : 0
-        print("isAgree: \(isAgree)")
-        print("requiredTermsCount: \(requiredTermsCount)")
     }
     
     func didTapOptionalTermsButton(terms: TermsModel) {
@@ -75,8 +71,6 @@ final class TermsViewModel: ObservableObject {
         } else {
             wholeTermsButton?.isSelected = false
         }
-        print("isAgree: \(isAgree)")
-        print("requiredTermsCount: \(requiredTermsCount)")
     }
     
     func didTapRequiredTermsButton(terms: TermsModel) {
@@ -91,7 +85,5 @@ final class TermsViewModel: ObservableObject {
         }
         
         isAgree = requiredTermsCount == requiredTermsArray.count ? true : false
-        print("isAgree: \(isAgree)")
-        print("requiredTermsCount: \(requiredTermsCount)")
     }
 }

--- a/teamplan/Sources/Views/Authentication/LoginView.swift
+++ b/teamplan/Sources/Views/Authentication/LoginView.swift
@@ -18,27 +18,23 @@ enum LoginViewState {
 
 struct LoginView: View {
     
-    private var signInViewModel = GoogleSignInButtonViewModel(scheme: .dark, style: .standard, state: .normal)
-    
-    @State private var showTermsView: Bool = false
-    @State private var showHomeView: Bool = false
-    @State private var showSignUpView: Bool = false
+    @EnvironmentObject var authViewModel: AuthenticationViewModel
     @State private var isLoading: Bool = false
-    @State private var isLogin: Bool = false
-    @State private var showAlert = false
-    
+    @State private var showAlert: Bool = false
     @AppStorage("mainViewState") var mainViewState: MainViewState?
     
-    @ObservedObject var vm = GoogleSignInButtonViewModel()
-    @EnvironmentObject var authViewModel: AuthenticationViewModel
+    private var signInViewModel = GoogleSignInButtonViewModel(scheme: .dark, style: .standard, state: .normal)
     
     let transition: AnyTransition = .asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading))
+    
+    
+    // MARK: View Config
     
     var body: some View {
         NavigationView {
             ZStack {
                 loginView
-                if self.isLoading {
+                if isLoading {
                     LoadingView().zIndex(1)
                 }
             }
@@ -51,7 +47,6 @@ struct LoginView: View {
             }
         }
     }
-    
     
     private var loginView: some View {
         VStack {
@@ -71,91 +66,86 @@ struct LoginView: View {
     private var buttons: some View {
         VStack(spacing: 18) {
             SignInWithAppleButton(
-                onRequest: {
-                    request in
-                    self.authViewModel.requestNonceSignInApple()
-                    request.requestedScopes = [.fullName, .email]
-                    request.nonce = self.authViewModel.nonce
-                },
-                onCompletion: { result in
-                    switch result {
-                    case .success(let authResults): // viewModel에서 처리
-                        switch authResults.credential {
-                        case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                            guard let appleIDToken = appleIDCredential.identityToken else {
-                                print("Unable to fetch identity token")
-                                return
-                            }
-                            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
-                                print("\(appleIDToken.debugDescription)")
-                                return
-                            }
-                            
-                            let credential = OAuthProvider.credential(
-                                withProviderID: "apple.com",
-                                idToken: idTokenString,
-                                rawNonce: self.authViewModel.nonce
-                            )
-                            Auth.auth().signIn(with: credential) { (authResult, error) in
-                                if let error = error {
-                                    print("\(error.localizedDescription)")
-                                    return
-                                }
-                                print("Apple Login Successful.")
-                                showHomeView = true
-                            }
-                        default:
-                            break
-                        }
-                    case .failure(let error):
-                        print("Apple 로그인 실패: \(error.localizedDescription)")
-                    }
-                }
+                onRequest: appleLoginRequest,
+                onCompletion: appleLoginProcess
             )
-            .padding(.horizontal)
-            .frame(height: 48)
-            .frame(maxWidth: .infinity)
-            .foregroundColor(Gen.Colors.blackColor.swiftUIColor)
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(Gen.Colors.blackColor.swiftUIColor, lineWidth: 1)
-            )
+            .signInButtonStyle()
             
             GoogleSignInButton(viewModel: self.signInViewModel) {
-                Task {
-                    do {
-                        self.isLoading = true
-                        let user = try await authViewModel.signInGoogle()
-                        
-                        switch user.status {
-                        case .exist:
-                            if await authViewModel.tryLogin() {
-                                self.isLoading = false
-                                withAnimation(.spring()) {
-                                    self.mainViewState = .main
-                                }
-                            } else {
-                                self.isLoading = false
-                                self.showAlert = true
-                            }
-                            
-                        case .new:
-                            self.isLoading = false
-                            withAnimation(.spring()) {
-                                self.mainViewState = .signup
-                            }
-                        }
-                        
-                    } catch {
-                        print(error.localizedDescription)
-                        self.isLoading = false
-                    }
-                }
+                googleLoginProcess()
             }
         }
         .padding(.horizontal, 55)
     }
+    
+    
+    // MARK: Function
+    
+    // Apple login
+    // TODO: Need Custom Exception
+    private func appleLoginRequest(request: ASAuthorizationAppleIDRequest) {
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = self.authViewModel.requestNonceSignInApple()
+    }
+    
+    private func appleLoginProcess(result: Result<ASAuthorization, Error>) {
+        switch result {
+        case .success(let authResult):
+            Task{
+                let userInfo = try await self.authViewModel.signInApple(with: authResult)
+                await socialLoginProcess(with: userInfo)
+            }
+        case .failure(let error):
+            print("Apple Social Login Falied: \(error.localizedDescription)")
+        }
+    }
+    
+    // Google login
+    // TODO: Need Custom Exception
+    private func googleLoginProcess() {
+        Task {
+            self.isLoading = true
+            do {
+                let userInfo = try await authViewModel.signInGoogle()
+                await socialLoginProcess(with: userInfo)
+            } catch {
+                print("Google login failed: \(error.localizedDescription)")
+                isLoading = false
+            }
+        }
+    }
+    
+    // Login Process
+    private func socialLoginProcess(with userInfo: AuthSocialLoginResDTO) async {
+        isLoading = false
+        switch userInfo.status {
+        case .exist:
+            if await authViewModel.tryLogin() {
+                withAnimation(.spring()) {
+                    mainViewState = .main
+                }
+            } else {
+                showAlert = true
+            }
+        case .new:
+            withAnimation(.spring()) {
+                mainViewState = .signup
+            }
+        }
+    }
 }
+     
+extension View {
+    func signInButtonStyle() -> some View {
+        self
+            .padding(.horizontal)
+            .frame(height: 48)
+            .frame(maxWidth: .infinity)
+            .foregroundColor(Gen.Colors.blackColor.swiftUIColor)
+            .background(RoundedRectangle(cornerRadius: 4).strokeBorder())
+    }
+}
+
 
  struct LoginView_Previews: PreviewProvider {
      static var previews: some View {


### PR DESCRIPTION
## Key Changes
* Tuist
  - Project.swift : tuist generate 수행 시, sinInApple capability 활성화를 위해 'teamplan.entitlements' 항목추가
* Apple Soical Login
  - 기존, LoginView 에서 진행되던 로그인 및 인증 로직들을 함수화 및 핵심로직은 Service 단으로 이동
  - 소셜로그인 결과를 기반으로 idToken 추출 및 FirebaseAuth 등록, 등록결과를 기반으로 서비스 사용자 객체구성 등
* Google Social Login
  - Apple 소셜로그인과 겹치는 부분을 함수화 및 공유
  -  FirebaseAuth 등록여부 기준으로 Login/SignUp 로직분화
  - KeyChain 등록로직
  - AuthSocialLoginResDTO 구성로직
* LoginView
  - 기능 및 View 관련 코드분화 및 리팩토링 진행
* AuthenticationViewModel
  - Apple 소셜로그인 관련, Nonce 로직수정
  - FirebaseAuth 등록을위해 EncodeNonce 와 RawNonce 이원화
  - Goolge & Apple 소셜로그인 기능 그룹화
* LoginService
  - 사용자 식별자 변경 : (기존) 이메일앞부분 + 소셜로그인 종류 : (변강) FirebaseAuth 에서 부여하는 uid
  - 식별자 변경으로 같은 이메일로 로그인 시 Apple/Google 상관없이 하나의 계정으로 접속확인
* Etc
  - 의미없는 코드 및 로그성 print구문 제거
  
## To Reviewers
LoginView 부분에 수정을 가했기에ㅠ 확인 부탁드립니다!
