### PR TITLE
[refact][add] Merge Mypage Service & View, Add AutoLogin feature

### DIFF
--- a/teamplan/Sources/App/TeamPlanApp.swift
+++ b/teamplan/Sources/App/TeamPlanApp.swift
@@ -15,6 +15,11 @@ struct TeamPlanApp: App {
     @StateObject var authViewModel = AuthenticationViewModel()
     @StateObject var termsViewModel = TermsViewModel()
   
+    // App Initialization
+    init(){
+        FirebaseApp.configure()
+    }
+    
     // MARK: Main
     
     var body: some Scene {
@@ -22,20 +27,11 @@ struct TeamPlanApp: App {
             IntroView()
                 .environmentObject(authViewModel)
                 .environmentObject(termsViewModel)
-                .onAppear(perform: initializeApp)
                 .onOpenURL(perform: handelOpenURL)
         }
     }
     
     // MARK: - private method
-    
-    private func initializeApp() {
-        configureFirebase()
-    }
-    
-    private func configureFirebase(){
-        FirebaseApp.configure()
-    }
 
     private func handelOpenURL(_ url: URL){
         GIDSignIn.sharedInstance.handle(url)

--- a/teamplan/Sources/Object/UserObject.swift
+++ b/teamplan/Sources/Object/UserObject.swift
@@ -17,6 +17,7 @@ enum UserStatus: String{
 enum Providers: String{
     case apple = "apple.com"
     case google = "google.com"
+    case firebase = "firebase.com"
     case unknown = "Unknown Providers"
 }
 

--- a/teamplan/Sources/Protocol/CoreDataManaging.swift
+++ b/teamplan/Sources/Protocol/CoreDataManaging.swift
@@ -35,7 +35,6 @@ final class CoredataMainController: CoredataProtocol {
     }
 }
 
-
 // MARK: - Basic
 protocol BasicObjectManage {
     associatedtype Entity: NSManagedObject
@@ -81,11 +80,12 @@ protocol ChallengeObjectManage: BasicObjectManage {
     
     func setObject(with object: Object) async throws
     func getObject(with challengeId: Int, and userId: String) async throws -> Object
-    func getObjects(with userId: String) async throws -> [Object]
-    
-    func getObjects(with userId: String) throws -> [Object]
     func deleteObject(with userId: String) throws
     func updateObject(with dto: DTO) throws
+    
+    func getObjects(with userId: String) throws -> [Object]
+    func getObjects(with userId: String) async throws -> [Object]
+    func getCompleteObjects(with userId: String) async throws -> Int
     func isObjectExist(with userId: String) -> Bool
 }
 
@@ -97,7 +97,6 @@ protocol LogObjectManage: BasicObjectManage {
     
     func getLatestObject(with userId: String) throws -> Object
     func getFullObjects(with userId: String) throws -> [Object]
-    func getPartialObjects(with userId: String, and syncedAt: Date) throws -> [Object]
     
     func deleteObject(with userId: String) throws
     func isObjectExist(with userId: String) -> Bool
@@ -138,11 +137,12 @@ enum EntityPredicate {
     case coreValue
     case user
     case stat
-    case fullChallenge
     case accessLog
     case projectList
     case project
+    case fullChallenge
     case singleChallenge
+    case completeChallenge
     case targetLog
     
     var format: String {
@@ -153,6 +153,8 @@ enum EntityPredicate {
             return "user_id == %@ AND project_id == %d"
         case .singleChallenge:
             return "user_id == %@ AND challenge_id == %d"
+        case .completeChallenge:
+            return "user_id == %@ AND status == %@"
         case .targetLog:
             return "user_id == %@ AND access_record > %@"
         }

--- a/teamplan/Sources/Protocol/FireStoreManaging.swift
+++ b/teamplan/Sources/Protocol/FireStoreManaging.swift
@@ -65,11 +65,13 @@ extension SingleDocsManage {
         let query = getFirestoreInstance()
             .collection(type.rawValue)
             .document(userId)
-        return try await query.getDocument()
+        let snapshot = try await query.getDocument()
+        return snapshot
     }
     
     func fetchDocsReference(with userId: String, and type: CollectionType) async throws -> DocumentReference {
-        return try await fetchDocsSnapshot(with: userId, and: type).reference
+        let snapshot = try await fetchDocsSnapshot(with: userId, and: type).reference
+        return snapshot
     }
 }
 

--- a/teamplan/Sources/Services/Challenge/ChallengeServicesFirestore.swift
+++ b/teamplan/Sources/Services/Challenge/ChallengeServicesFirestore.swift
@@ -14,6 +14,8 @@ final class ChallengeServicesFirestore: ChallengeDocsManage {
     typealias infoDTO = ChallengeInfoDTO
     typealias statusDTO = ChallengeStatusDTO
     
+    //MARK: Function
+    
     func setDocs(with objects: [Object], and userId: String) async throws {
         let batch = getFirestoreInstance().batch()
         let collectionRef = fetchCollection(with:.challengeStatus)
@@ -119,7 +121,7 @@ extension ChallengeServicesFirestore {
               let stringFinishedAt = data["finished_at"] as? String,
               let finishedAt = DateFormatter.standardFormatter.date(from: stringFinishedAt)
         else {
-            throw FirestoreError.convertFailure(serviceName: .challenge)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .challenge)
         }
         return statusDTO (
             challengeId: challengeId,
@@ -145,7 +147,7 @@ extension ChallengeServicesFirestore {
               let reward = data["chlg_reward"] as? Int,
               let step = data["chlg_step"] as? Int
         else {
-            throw FirestoreError.convertFailure(serviceName: .challenge)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .challenge)
         }
         return infoDTO (
             challengeId: challengeId,

--- a/teamplan/Sources/Services/CoreValue/CoreValueServicesCoredata.swift
+++ b/teamplan/Sources/Services/CoreValue/CoreValueServicesCoredata.swift
@@ -59,7 +59,7 @@ extension CoreValueServicesCoredata {
     
     private func convertToObject(with entity: CoreValueEntity) throws -> CoreValueObject {
         guard let userId = entity.user_id else {
-            throw CoredataError.convertFailure(serviceName: .coreValue)
+            throw CoredataError.convertFailure(serviceName: .cd, dataType: .coreValue)
         }
         return CoreValueObject(
             userId: userId,
@@ -79,7 +79,7 @@ extension CoreValueServicesCoredata {
     private func getEntity(with userId: String) throws -> CoreValueEntity {
         let reqeust = getFetchReqeust(with: userId)
         guard let entity = try fetchEntity(with: reqeust, and: self.context) else {
-            throw CoredataError.fetchFailure(serviceName: .coreValue)
+            throw CoredataError.fetchFailure(serviceName: .cd, dataType: .coreValue)
         }
         return entity
     }

--- a/teamplan/Sources/Services/CoreValue/CoreValueServicesFirestore.swift
+++ b/teamplan/Sources/Services/CoreValue/CoreValueServicesFirestore.swift
@@ -15,7 +15,7 @@ final class CoreValueServicesFirestore: BasicDocsManage {
     
     func getDocs(with userId: String) async throws -> CoreValueObject {
         guard let data = try await fetchDocument(with: .coreValue).data() else {
-            throw FirestoreError.fetchFailure(serviceName: .coreValue)
+            throw FirestoreError.fetchFailure(serviceName: .fs, dataType: .coreValue)
         }
         return try convertToObject(with: userId, and: data)
     }
@@ -29,7 +29,7 @@ extension CoreValueServicesFirestore {
               let dropRation = data["drop_ratio"] as? Float,
               let syncCycle = data["sync_cycle"] as? Int
         else {
-            throw FirestoreError.convertFailure(serviceName: .coreValue)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .coreValue)
         }
         return CoreValueObject(
             userId: userId,

--- a/teamplan/Sources/Services/Log/AccessLogServicesCoredata.swift
+++ b/teamplan/Sources/Services/Log/AccessLogServicesCoredata.swift
@@ -23,21 +23,15 @@ final class AccessLogServicesCoredata: LogObjectManage {
         try self.context.save()
     }
     
-    // Single Log
+    // Get: Single Log
     func getLatestObject(with userId: String) throws -> Object {
         let entity = try getLatestEntity(with: userId)
         return try convertToObject(with: entity)
     }
     
-    // Full Log
+    // Get: Full Log
     func getFullObjects(with userId: String) throws -> [Object] {
         let entities = try getFullEntity(with: userId)
-        return try convertToObjects(with: entities)
-    }
-    
-    // SyncedAt ~ Recent Log
-    func getPartialObjects(with userId: String, and syncedAt: Date) throws -> [Object] {
-        let entities = try getPartialEntity(with: userId, at: syncedAt)
         return try convertToObjects(with: entities)
     }
     
@@ -84,7 +78,7 @@ extension AccessLogServicesCoredata{
         request.fetchLimit = 1
         
         guard let entity = try self.context.fetch(request).first else {
-            throw CoredataError.fetchFailure(serviceName: .log)
+            throw CoredataError.fetchFailure(serviceName: .cd, dataType: .log)
         }
         return entity
     }
@@ -95,27 +89,12 @@ extension AccessLogServicesCoredata{
     }
     
     
-    // Partial entity
-    private func getPartialFetchRequest(with userId: String, at syncedAt: Date) -> NSFetchRequest<Entity> {
-        let fetchRequest: NSFetchRequest<Entity> = Entity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: EntityPredicate.targetLog.format, userId, syncedAt as NSDate)
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: EntitySortBy.date.rawValue, ascending: false)]
-        
-        return fetchRequest
-    }
-
-    private func getPartialEntity(with userId: String, at syncedAt: Date) throws -> [Entity] {
-        let request = getPartialFetchRequest(with: userId, at: syncedAt)
-        return try self.context.fetch(request)
-    }
-    
-    
     // Converter
     private func convertToObject(with entity: Entity) throws -> Object {
         guard let userId = entity.user_id,
               let accessRecord = entity.access_record
         else {
-            throw CoredataError.convertFailure(serviceName: .log)
+            throw CoredataError.convertFailure(serviceName: .cd, dataType: .log)
         }
         return AccessLog(userId: userId, accessDate: accessRecord)
     }

--- a/teamplan/Sources/Services/Log/AccessLogServicesFirestore.swift
+++ b/teamplan/Sources/Services/Log/AccessLogServicesFirestore.swift
@@ -56,7 +56,7 @@ extension AccessLogServicesFirestore {
               let stringAccessRecord = data["access_record"] as? String,
               let accessRecord = DateFormatter.standardFormatter.date(from: stringAccessRecord)
         else {
-            throw FirestoreError.convertFailure(serviceName: .log)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .log)
         }
         return AccessLog(userId: userId, accessDate: accessRecord)
     }

--- a/teamplan/Sources/Services/Project/ProjectServicesFirestore.swift
+++ b/teamplan/Sources/Services/Project/ProjectServicesFirestore.swift
@@ -28,7 +28,7 @@ final class ProjectServicesFirestore: ProjectDocsManage {
     
     func getDocs(with projectId: Int, and userId: String) async throws -> ProjectObject {
         guard let data = try await fetchSingleDocsSnapshot(userId: userId, projectId: projectId, type: .project).data() else {
-            throw FirestoreError.fetchFailure(serviceName: .project)
+            throw FirestoreError.fetchFailure(serviceName: .fs, dataType: .project)
         }
         return try convertToObject(with: data)
     }
@@ -94,7 +94,7 @@ extension ProjectServicesFirestore {
               let stringSyncedAt = data["synced_at"] as? String,
               let syncedAt = DateFormatter.standardFormatter.date(from: stringSyncedAt)
         else {
-            throw FirestoreError.convertFailure(serviceName: .project)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .project)
         }
         return ProjectObject(
             projectId: projectId,

--- a/teamplan/Sources/Services/Project/TodoServicesCoredata.swift
+++ b/teamplan/Sources/Services/Project/TodoServicesCoredata.swift
@@ -75,7 +75,7 @@ extension TodoServiceCoredata{
         fetchReq.fetchLimit = 1
         
         guard let entity = try self.context.fetch(fetchReq).first else {
-            throw CoredataError.fetchFailure(serviceName: .todo)
+            throw CoredataError.fetchFailure(serviceName: .cd, dataType: .project)
         }
         return entity
     }
@@ -85,7 +85,7 @@ extension TodoServiceCoredata{
         let projectEntity = try getProjectEntity(userId: userId, projectId: projectId)
         
         guard let todoEntities = projectEntity.todo_relationship as? Set<Entity> else {
-            throw TodoErrorCD.UnexpectedFetchError
+            throw CoredataError.fetchFailure(serviceName: .cd, dataType: .todo)
         }
         return Array(todoEntities)
     }
@@ -93,7 +93,7 @@ extension TodoServiceCoredata{
     // Fetch: Single Todo
     private func getEntity(userId: String, projectId: Int, todoId: Int) throws -> TodoEntity {
         guard let entity = try getEntities(userId: userId, projectId: projectId).first(where: { $0.todo_id == todoId }) else {
-            throw TodoErrorCD.UnexpectedSearchError
+            throw CoredataError.searchFailure(serviceName: .cd, dataType: .todo)
         }
         return entity
     }
@@ -103,7 +103,7 @@ extension TodoServiceCoredata{
         guard let userId = entity.user_id,
               let desc = entity.desc,
               let status = TodoStatus(rawValue: Int(entity.status)) else {
-            throw CoredataError.convertFailure(serviceName: .todo)
+            throw CoredataError.convertFailure(serviceName: .cd, dataType: .todo)
         }
         return TodoObject(
             projectId: Int(entity.project_id),
@@ -154,29 +154,5 @@ struct TodoUpdateDTO{
         self.newDesc = newDesc
         self.newStatus = newStatus
         self.newPinned = newPinned
-    }
-}
-
-
-//===============================
-// MARK: - Exception
-//===============================
-enum TodoErrorCD: LocalizedError {
-    case UnexpectedFetchError
-    case UnexpectedConvertError
-    case UnexpectedSearchError
-    case UnexpectedNilError
-    
-    var errorDescription: String?{
-        switch self {
-        case .UnexpectedFetchError:
-            return "Coredata: There was an unexpected error while Fetch 'Todo' details"
-        case .UnexpectedConvertError:
-            return "Coredata: There was an unexpected error while Convert 'Todo' details"
-        case .UnexpectedSearchError:
-            return "Coredata: There was an unexpected error while Search 'Todo' details"
-        case .UnexpectedNilError:
-            return "Coredata: There was an unexpected Nil error while Get 'TodoId'"
-        }
     }
 }

--- a/teamplan/Sources/Services/ProjectService.swift
+++ b/teamplan/Sources/Services/ProjectService.swift
@@ -10,6 +10,7 @@ import Foundation
 
 final class ProjectService {
     
+    // Service Propertise
     private let coreValueCD = CoreValueServicesCoredata()
     private let statCD = StatisticsServicesCoredata()
     private let projectCD = ProjectServicesCoredata()
@@ -20,9 +21,11 @@ final class ProjectService {
     var statData: StatisticsObject = StatisticsObject()
     var coreValue: CoreValueObject = CoreValueObject()
     
+    // Shared DTO
     @Published var statDashBoard: ProjectStatDTO = ProjectStatDTO()
     @Published var projectList: [ProjectDTO] = []
     
+    // Initializer
     init(userId: String) {
         self.userId = userId
     }
@@ -144,6 +147,7 @@ extension ProjectService {
     }
     
     // Convert inputDrop to newDeadLine
+    // TODO: Need Custom Exception
     func calcDeadLineWithDrop(projectId: Int, inputDrop: Int) throws -> Date {
         let convertRatio = coreValue.dropConvertRatio
         let index = try searchProjectIndex(with: projectId)
@@ -152,13 +156,13 @@ extension ProjectService {
         let extend = inputDrop * Int(convertRatio)
         
         guard let updatedDeadline = Calendar.current.date(byAdding: .day, value: extend, to: currentDeadline) else {
-            // TODO: Custom Error
-            throw CoredataError.convertFailure(serviceName: .project)
+            throw CoredataError.convertFailure(serviceName: .project, dataType: .project)
         }
         return updatedDeadline
     }
     
     // Convert newDeadLine to needDrop
+    // TODO: Need Custom Exception
     func calcDeadlineWithDate(with projectId: Int, and newDate: Date) throws -> Int {
         let convertRatio = coreValue.dropConvertRatio
         let index = try searchProjectIndex(with: projectId)
@@ -167,8 +171,7 @@ extension ProjectService {
         let component = Calendar.current.dateComponents([.day], from: currentDeadline, to: newDate)
         
         guard let extendDays = component.day else {
-            // TODO: Custom Error
-            throw CoredataError.convertFailure(serviceName: .project)
+            throw CoredataError.convertFailure(serviceName: .project, dataType: .project)
         }
         return extendDays * Int(convertRatio)
     }
@@ -249,18 +252,19 @@ extension ProjectService {
         return 0
     }
     
+    // TODO: Need Custom Exception
     private func searchProjectIndex(with projectId: Int) throws -> Int {
         guard let index = self.projectList.firstIndex(where: { $0.projectId == projectId }) else {
-            // TODO: Custom Error
-            throw CoredataError.fetchFailure(serviceName: .project)
+            throw CoredataError.convertFailure(serviceName: .project, dataType: .project)
         }
         return index
     }
     
+    // TODO: Need Custom Exception
     private func searchTodoIndex(with projectIndex: Int, and todoId: Int) throws -> Int  {
         guard let index = self.projectList[projectIndex].todoList.firstIndex(where: { $0.todoId == todoId }) else {
             // TODO: Custom Error
-            throw CoredataError.fetchFailure(serviceName: .project)
+            throw CoredataError.convertFailure(serviceName: .project, dataType: .project)
         }
         return index
     }

--- a/teamplan/Sources/Services/SignupLoadingService.swift
+++ b/teamplan/Sources/Services/SignupLoadingService.swift
@@ -30,6 +30,7 @@ final class SignupLoadingService{
     private let newStat: StatisticsObject
     private let newLog: AccessLog
     
+    private var challengeIdSet = Set<Int>()
     private var rollbackStack: [() async throws -> Void ] = []
     
     
@@ -220,7 +221,8 @@ extension SignupLoadingService{
     private func setNewChallengeAtLocal() async throws {
         
         let challengeInfo = try await challengeFS.getInfoDocsList()
-        for challenge in challengeInfo {
+        for challenge in challengeInfo where !challengeIdSet.contains(challenge.challengeId) {
+            challengeIdSet.insert(challenge.challengeId)
             let object = prepareNewChallengeStatus(with: challenge)
             try await challengeCD.setObject(with: object)
         }

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
@@ -90,7 +90,7 @@ extension StatisticsServicesCoredata {
     private func getEntity(with userId: String) throws -> Entity {
         let request = getFetchRequest(with: userId)
         guard let entity = try fetchEntity(with: request, and: self.context) else {
-            throw CoredataError.fetchFailure(serviceName: .stat)
+            throw CoredataError.fetchFailure(serviceName: .cd, dataType: .stat)
         }
         return entity
     }
@@ -100,7 +100,7 @@ extension StatisticsServicesCoredata {
               let challengeStepStatusString = entity.challenge_step_status,
               let myChallengesString = entity.mychallenges 
         else {
-            throw CoredataError.convertFailure(serviceName: .stat)
+            throw CoredataError.convertFailure(serviceName: .cd, dataType: .stat)
         }
         let challengeStepStatus = try Utilities().convertFromJSON(jsonString: challengeStepStatusString, type: [Int: Int].self)
         let myChallenges = try Utilities().convertFromJSON(jsonString: myChallengesString, type: [Int].self)

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesFirestore.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesFirestore.swift
@@ -21,7 +21,7 @@ final class StatisticsServicesFirestore: SingleDocsManage {
     
     func getDocs(with userId: String) async throws -> Object {
         guard let data = try await fetchDocsSnapshot(with: userId, and: .stat).data() else {
-            throw FirestoreError.fetchFailure(serviceName: .stat)
+            throw FirestoreError.fetchFailure(serviceName: .fs, dataType: .stat)
         }
         return try convertToObject(with: data)
     }
@@ -73,7 +73,7 @@ extension StatisticsServicesFirestore {
               let stringSyncedAt = data["synced_at"] as? String,
               let syncedAt = DateFormatter.standardFormatter.date(from: stringSyncedAt)
         else {
-            throw FirestoreError.convertFailure(serviceName: .stat)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .stat)
         }
         
         let challengeStepStatus = try Utilities().convertFromJSON(jsonString: challengeStepStatusString, type: [Int: Int].self)

--- a/teamplan/Sources/Services/User/UserServicesCoredata.swift
+++ b/teamplan/Sources/Services/User/UserServicesCoredata.swift
@@ -86,7 +86,7 @@ extension UserServicesCoredata{
     private func getEntity(with userId: String) throws -> Entity {
         let request = getFetchRequest(with: userId)
         guard let entity = try fetchEntity(with: request, and: self.context) else {
-            throw CoredataError.fetchFailure(serviceName: .user)
+            throw CoredataError.fetchFailure(serviceName: .cd, dataType: .user)
         }
         return entity
     }
@@ -103,7 +103,7 @@ extension UserServicesCoredata{
               let changedAt = entity.changed_at,
               let syncedAt = entity.synced_at
         else {
-            throw CoredataError.convertFailure(serviceName: .user)
+            throw CoredataError.convertFailure(serviceName: .cd, dataType: .user)
         }
         return UserObject(
             userId: userId,

--- a/teamplan/Sources/Services/User/UserServicesFirestore.swift
+++ b/teamplan/Sources/Services/User/UserServicesFirestore.swift
@@ -21,7 +21,7 @@ final class UserServicesFirestore: SingleDocsManage {
     
     func getDocs(with userId: String) async throws -> UserObject {
         guard let data = try await fetchDocsSnapshot(with: userId, and: .user).data() else {
-            throw FirestoreError.fetchFailure(serviceName: .user)
+            throw FirestoreError.fetchFailure(serviceName: .fs, dataType: .user)
         }
         return try convertToObject(with: data)
     }
@@ -69,7 +69,7 @@ extension UserServicesFirestore{
               let stringSyncedAt = data["synced_at"] as? String,
               let syncedAt = DateFormatter.standardFormatter.date(from: stringSyncedAt)
         else {
-            throw FirestoreError.convertFailure(serviceName: .user)
+            throw FirestoreError.convertFailure(serviceName: .fs, dataType: .user)
         }
         return UserObject(
             userId: userId,

--- a/teamplan/Sources/Util/Utilities.swift
+++ b/teamplan/Sources/Util/Utilities.swift
@@ -10,22 +10,6 @@ import Foundation
 
 final class Utilities {
     
-    // MARK: Extract Identifier
-    func getIdentifier(from authRes: AuthSocialLoginResDTO) throws -> String {
-        
-        let accountName = try getAccountName(from: authRes.email ?? "")
-        return "\(accountName)_\(authRes.provider.rawValue)"
-    }
-    // Account Name
-    private func getAccountName(from userEmail: String) throws -> String {
-        
-        guard let atIndex = userEmail.firstIndex(of: "@"), atIndex != userEmail.startIndex else {
-            throw UtilError.InvalidEmailFormat
-        }
-        return (String(userEmail.prefix(upTo: atIndex)))
-    }
-
-    
     // MARK: Time Calculator
     // Compare
     func compareTime(currentTime: Date, lastTime: Date) -> Bool {

--- a/teamplan/Sources/ViewModels/MypageViewModel.swift
+++ b/teamplan/Sources/ViewModels/MypageViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  MypageViewModel.swift
+//  teamplan
+//
+//  Created by 크로스벨 on 5/1/24.
+//  Copyright © 2024 team1os. All rights reserved.
+//
+
+import Foundation
+
+final class MypageViewModel: ObservableObject {
+    
+    //MARK: Properties
+    
+    @Published var userName: String
+    @Published var dto: MypageDTO
+    @Published var accomplishes: [Accomplishment]
+    
+    private let identifier: String
+    private let service: MypageService
+    
+    //MARK: Initializer
+    // prepare prepertise : UserDefault (userName / Identifier)
+    init() {
+        if let userDefault = UserDefaultManager.loadWith(key: UserDefaultKey.user.rawValue),
+           let identifier = userDefault.identifier,
+           let userName = userDefault.userName {
+            self.identifier = identifier
+            self.userName = userName
+        } else {
+            self.identifier = "unknown"
+            self.userName = "unknown"
+            print("[MypageViewModel] Initialize Failed")
+        }
+        self.service = MypageService(userId: self.identifier)
+        self.dto = MypageDTO()
+        self.accomplishes = []
+    }
+    
+    //MARK: Method
+    
+    func loadData() {
+        Task {
+            self.dto = try service.getMypageDTO()
+            self.accomplishes = [
+                .init(accomplishTitle: AccomplishmentTitle.challenge.rawValue, accomplishCount: dto.completedChallenges),
+                .init(accomplishTitle: AccomplishmentTitle.project.rawValue, accomplishCount: dto.completedProjects),
+                .init(accomplishTitle: AccomplishmentTitle.todo.rawValue, accomplishCount: dto.completedTodos)
+            ]
+        }
+    }
+    
+    func performAction(menu: MypageMenu) throws {
+        switch menu {
+            
+        case .logout:
+            do {
+                try service.logout()
+            } catch let error as NSError {
+                print(error)
+            }
+            
+        case .withdraw:
+            Task{ try await service.withdraw() }
+ 
+        default:
+            return
+        }
+    }
+}
+
+enum AccomplishmentTitle: String {
+    case challenge = "완료 도전과제"
+    case project = "완료한 목표"
+    case todo = "완료한 할 일"
+}

--- a/teamplan/Sources/Views/Home/HomeView.swift
+++ b/teamplan/Sources/Views/Home/HomeView.swift
@@ -105,14 +105,10 @@ extension HomeView {
             Spacer()
             
             Button {
-                do {
-                    let google = AuthGoogleService()
-                    try google.logout()
-                    withAnimation(.easeIn(duration: 10)) {
-                        mainViewState = .login
-                    }
-                } catch {
-                    print(error)
+                let service = LoginService()
+                service.logoutUser()
+                withAnimation(.easeIn(duration: 10)) {
+                    mainViewState = .login
                 }
             } label: {
                 Text("로그아웃")

--- a/teamplan/Sources/Views/MyPage/MyPageView.swift
+++ b/teamplan/Sources/Views/MyPage/MyPageView.swift
@@ -10,126 +10,106 @@ import SwiftUI
 
 struct MyPageView: View {
     
+    @ObservedObject private var vm = MypageViewModel();
+    
     // MARK: - private properties
     
     private var leftRightInset: CGFloat = 16
-    private var menuTitles: [String] = ["가이드북", "로그아웃", "회원탈퇴", "앱 버전"]
-    
-    private var savedBombAttrString: AttributedString {
-        let targetString = "\(self.savedBomb)개"
-        var targetAttributed = AttributedString(targetString)
-        targetAttributed.foregroundColor = .black
-        return targetAttributed
-    }
-    
-    private var disappearedBombAttrString: AttributedString {
-        let targetString = "\(self.disappearedBomb)개"
-        var targetAttributed = AttributedString(targetString)
-        targetAttributed.foregroundColor = .black
-        return targetAttributed
-    }
-    
-    
-    // MARK: - properties
-    
-    // FIXME: need data binding
-    
-    var sinceDays: Int = 1
-    var savedBomb = 3
-    var disappearedBomb = 3
-    
-    var accomplishes: [Accomplishment] = [
-        .init(accomplishTitle: "완료 도전과제", accomplishCount: 10),
-        .init(accomplishTitle: "완료한 목표", accomplishCount: 12),
-        .init(accomplishTitle: "완료한 할 일", accomplishCount: 12)
-    ]
-    
+    private var menuTitles: [MypageMenu] = [.guide, .logout, .withdraw, .version]
     
     // MARK: - body
     
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading) {
-                Text("마이페이지")
-                    .font(.title)
-                    .bold()
-                    .foregroundStyle(.purple)
-                    .frame(height: 60)
-                
-                HStack(spacing: 20) {
-//                    Image("project_empty")
-                    Image(uiImage: Gen.Images.projectEmpty.image)
-                    
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack(alignment: .center, spacing: 4) {
-                            Text("김하나 지킴이")
-                                .frame(alignment: .leading)
-                                .font(.appleSDGothicNeo(.bold, size: 20))
-                            Image("Pencil")
-                        }
-                        HStack {
-                            Text(AttributedString("지켜낸 폭탄맨 ") + self.savedBombAttrString)
-                                .foregroundStyle(.purple)
-                            Text("사라진 폭탄맨 " + self.disappearedBombAttrString)
-                                .foregroundStyle(.purple)
-                        }
-                    }
-                }
-                
-                Divider()
-                    .background(.black.opacity(0.6))
-                    .frame(height: 1)
-                    .padding(.init(top: 20, leading: .zero, bottom: 0, trailing: .zero))
-                
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("투두팡과 함께한 추억")
-                        .font(.title3)
-                        .bold()
-                    HStack {
-                        Image("Time")
-                        Text("투두팡과 \(sinceDays)일 동안 함께 했어요")
-                        Spacer()
-                    }
-                }
-                .padding(
-                    .init(
-                        top: 18,
-                        leading: .zero,
-                        bottom: 10,
-                        trailing: .zero
-                    )
-                )
-                
-                AccomplishmentView(accomplishes: self.accomplishes)
-                    .frame(maxWidth: .infinity, minHeight: 78)
-
-                Divider()
-                    .background(.black.opacity(0.6))
-                    .frame(height: 1)
-                    .padding(
-                        .init(
-                            top: 30,
-                            leading: .zero,
-                            bottom: .zero,
-                            trailing: .zero
-                        )
-                    )
+                headerSection
+                historySection
+                accomplishmentsSection
             }
             .padding(.init(top: 0, leading: self.leftRightInset, bottom: 0, trailing: self.leftRightInset))
+            menuList
+        }
+        .onAppear {
+            vm.loadData()
+        }
+    }
+    
+    // MARK: Section
+    
+    private var headerSection: some View {
+        VStack {
+            Text("마이페이지")
+                .font(.archivoBlack(.regular, size: 20))
+                .foregroundStyle(Color.theme.mainPurpleColor)
             
-            List {
-                ForEach(menuTitles, id: \.self) { title in
-                    if title == "앱 버전" {
-                        MenuItemView(title: "앱 버전", showArrow: false)
-                    } else {
-                        MenuItemView(title: title, showArrow: true)
+            HStack(spacing: 20) {
+                Image(uiImage: Gen.Images.projectEmpty.image)
+                
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .center, spacing: 4) {
+                        Text("\(vm.userName) 지킴이")
+                            .font(.appleSDGothicNeo(.bold, size: 20))
+                        Image("Pencil")
+                    }
+                    HStack {
+                        Text(AttributedString("지켜낸 폭탄맨 ") + attributedString(for: vm.dto.protected))
+                            .foregroundStyle(.purple)
+                        Text("사라진 폭탄맨 " + attributedString(for: vm.dto.destroyed))
+                            .foregroundStyle(.purple)
                     }
                 }
             }
-            .scrollDisabled(true)
-            .listStyle(.plain)
+            Divider()
+                .background(.black.opacity(0.6))
+                .frame(height: 1)
+                .padding(.init(top: 20, leading: .zero, bottom: 0, trailing: .zero))
         }
-        
+    }
+    
+    private var historySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("투두팡과 함께한 추억")
+                .font(.title3)
+                .bold()
+            HStack {
+                Image("Time")
+                Text("투두팡과 \(vm.dto.serviceTerm)일 동안 함께 했어요")
+                Spacer()
+            }
+        }
+        .padding(.init(top: 18, leading: .zero, bottom: 10, trailing: .zero))
+    }
+    
+    private var accomplishmentsSection: some View {
+        VStack {
+            AccomplishmentView(accomplishes: vm.accomplishes)
+                .frame(maxWidth: .infinity, minHeight: 78)
+
+            Divider()
+                .background(Color.black.opacity(0.6))
+                .frame(height: 1)
+                .padding(.init(top: 30, leading: .zero, bottom: .zero, trailing: .zero))
+        }
+    }
+    
+    private var menuList: some View {
+        List {
+            ForEach(menuTitles, id: \.self) { title in
+                MenuItemView(title: title.rawValue, showArrow: title != .version)
+            }
+        }
+        .scrollDisabled(true)
+        .listStyle(.plain)
+    }
+}
+
+//MARK: Support
+
+extension MyPageView {
+    private func attributedString(for count: Int) -> AttributedString {
+        var attributed = AttributedString("\(count)개")
+        attributed.foregroundColor = .black
+        return attributed
     }
 }
 

--- a/teamplan/Sources/Views/Onboarding/IntroView.swift
+++ b/teamplan/Sources/Views/Onboarding/IntroView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import KeychainSwift
+import FirebaseAuth
 
 enum MainViewState: Int {
     case login
@@ -15,10 +15,13 @@ enum MainViewState: Int {
 }
 
 struct IntroView: View {
+    
     @AppStorage("isOnboarding") var isOnboarding: Bool = true
     @AppStorage("mainViewState") var mainViewState: MainViewState = .login
+    
     @StateObject var notificationViewModel = NotificationViewModel()
-    @State private var hasCheckedLoginStatus = false
+    @State private var isLoading: Bool = false
+    
     @EnvironmentObject var authViewModel: AuthenticationViewModel
     
     var body: some View {
@@ -27,25 +30,94 @@ struct IntroView: View {
                 OnboardingView()
                     .transition(.asymmetric(insertion: .move(edge: .top), removal: .move(edge: .bottom)))
             } else {
-                switch mainViewState {
-                case .login:
-                    LoginView()
-                        .environmentObject(notificationViewModel)
-                        .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .move(edge: .top)))
-                case .signup:
-                    SignupView()
-                        .environmentObject(notificationViewModel)
-                        .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .move(edge: .top)))
-                case .main:
-                    MainTapView()
-                        .environmentObject(notificationViewModel)
-                        .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .move(edge: .top)))
+                if isLoading {
+                    LoadingView()
+                } else {
+                    moveToMainView
                 }
             }
         }
         .onAppear {
-            checkLoginStatus()
+            Task {
+                await autoLoginProcess()
+            }
         }
+    }
+    
+    @ViewBuilder
+    private var moveToMainView: some View {
+        switch mainViewState {
+        case .login:
+            LoginView().environmentObject(notificationViewModel)
+        case .signup:
+            SignupView().environmentObject(notificationViewModel)
+        case .main:
+            MainTapView().environmentObject(notificationViewModel)
+        }
+    }
+}
+
+extension IntroView {
+    
+    // Main Executor
+    private func autoLoginProcess() async {
+        isLoading = true
+        
+        guard let user = Auth.auth().currentUser else {
+            print("[AutoLogin] There is no currently logged in user")
+            setReloginStatus()
+            return
+        }
+        
+        if await isReLoginNeeded(with: user) {
+            prepareAuthDTO(with: user)
+            let loginSuccess = await authViewModel.tryLogin()
+            self.mainViewState = loginSuccess ? .main : .login
+        } else {
+            setReloginStatus()
+        }
+        isLoading = false
+    }
+    
+    // check: FirebaseAuth refresh token
+    private func isReLoginNeeded(with user: User) async -> Bool {
+        do {
+            try await user.getIDTokenResult(forcingRefresh: true)
+            print("[AutoLogin] Successfully get refreshed token")
+            return true
+        } catch {
+            print("[AutoLogin] Failed to refresh token: \(error)")
+            await logoutAndRedirectToLogin()
+            return false
+        }
+    }
+    
+    // struct: AuthSocialLoginDTO for 'loginLoadingService'
+    private func prepareAuthDTO(with user: User) {
+        self.authViewModel.signupUser = AuthSocialLoginResDTO(
+            identifier: user.uid,
+            email: user.email ?? "UnknownEmail",
+            provider: .firebase,
+            idToken: "",
+            accessToken: "",
+            status: .exist
+        )
+    }
+    
+    // exception: logout at firebaseAuth
+    private func logoutAndRedirectToLogin() async {
+        do {
+            try Auth.auth().signOut()
+        } catch {
+            print("[AutoLogin] Failed to Logout at FirebaseAuth: \(error)")
+        }
+        setReloginStatus()
+    }
+    
+    // exception: change view state
+    private func setReloginStatus() {
+        self.mainViewState = .login
+        self.isLoading = false
     }
 }
 
@@ -55,22 +127,5 @@ struct IntroView_Previews: PreviewProvider {
     }
 }
 
-extension IntroView {
-    
-    private func checkLoginStatus() {
-        guard !hasCheckedLoginStatus else {
-            return
-        }
-        
-        let userDefaultManager = UserDefaultManager.loadWith(key: "user")
-        let identifier = userDefaultManager?.identifier
-        
-        if let identifier = identifier, !identifier.isEmpty {
-            self.mainViewState = .main
-        } else {
-            self.mainViewState = .login
-        }
-        
-        hasCheckedLoginStatus = true
-    }
-}
+
+

--- a/teamplan/Sources/Views/Project/ProjectView.swift
+++ b/teamplan/Sources/Views/Project/ProjectView.swift
@@ -43,7 +43,7 @@ struct ProjectView_Previews: PreviewProvider {
 extension ProjectView {
     private var navigationArea: some View {
         HStack {
-            Text("프로젝트")
+            Text("목표")
                 .font(.archivoBlack(.regular, size: 20))
                 .foregroundColor(.theme.mainPurpleColor)
             Spacer()


### PR DESCRIPTION
## Key Changes
* [App]
  - Firebase 활성화코드 위치변경 : init() 도입으로, 보다빠른 Firebase 설정수행
* [Protocol]
  - ServiceError : Coredata/Firestore/SocialLogin/Login & Signup 커스텀 예외처리 도입
* [Repository]
  - Coredata & Firestore : 커스텀 예외처리 적용
  - AccessLog : 불필요 AccessLog 관련 Get함수 제거
  - Challenge : ChallengeObject 호출없이, 객체의 개수정보 반환 함수 추가
* [Business]
  - Login : Apple/Google 소셜로그인 모두 적용되는 Logout 로직구성 : KeyChain 및 UserDefault 초기화 로직적용
  - LoginLoading : 안정적인 업데이트 수행 및 적용을 위해 async/await 방식 적용 : 정상적인 로그인 수행 확인을 위해 중요 분기에 print() 추가
  - SignupLoading : 신규 사용자 생성 시, 서버에서 ChallengeData 를 가져오는 과정에 ChallengeID 중복검사 로직추가
  - Challenge : prepareService() 내, dictionary 생성시 challengeId 중복검사 로직추가
  - Mypage : 서비스 사용일 및 완료 도전과제 개수 추출로직 추가
* [ViewModel]
  - Authentication : 로그인/회원가입 과정 중 UserDefault 활성화 로직 리팩토링
  - Home : 활성화 중 UserDefault 활성화 로직 리팩토링
  - MyPage : View 에서 필요한 데이터 바인딩 수행
* [View]
  - Home : 로그아웃 기능함수 변경
  - MyPage : Section 별 View 재구성 : 더미데이터를 ViewModel 데이터로 변경
  - Intro : 자동로그인 로직도입 : FirebaseAuth 내 세션기능을 통해 구현 : 과정 내 LoginLoading 서비스를 추가, 재로그인 경우에도 stat 조정가능

  
## To Reviewers
확인 부탁드립니다! 감사합니다~
