### PR TITLE
[refact] Home(View, ViewModel, Service) & ETC

### DIFF
--- a/teamplan/Sources/Util/Utilities.swift
+++ b/teamplan/Sources/Util/Utilities.swift
@@ -20,7 +20,10 @@ final class Utilities {
     // D-Day
     func calculateDatePeroid(with start: Date, and end: Date) throws -> Int {
         
-        let calendar = Calendar.current
+        // For accurate date calculation, force timezone to UTC
+        var calendar = Calendar.current
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        
         let startDate = calendar.startOfDay(for: start)
         let endDate = calendar.startOfDay(for: end)
         
@@ -99,6 +102,12 @@ extension DateFormatter {
     static let standardFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+    
+    static let shortFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy.MM.dd"
         return formatter
     }()
 }

--- a/teamplan/Sources/ViewModels/AuthenticationViewModel.swift
+++ b/teamplan/Sources/ViewModels/AuthenticationViewModel.swift
@@ -42,6 +42,7 @@ final class AuthenticationViewModel: ObservableObject {
     
     
     // MARK: - Login
+    @MainActor
     func tryLogin() async -> Bool {
         // check: user data
         guard let loginUser = self.signupUser else { return false }
@@ -62,6 +63,7 @@ final class AuthenticationViewModel: ObservableObject {
     }
     
     //MARK: - Signup
+    @MainActor
     func trySignup(userName: String) async throws -> UserInfoDTO {
         // check: user data
         guard let signupUser = self.signupUser else { throw SignupError.invalidUser }

--- a/teamplan/Sources/ViewModels/HomeViewModel.swift
+++ b/teamplan/Sources/ViewModels/HomeViewModel.swift
@@ -11,74 +11,85 @@ import Combine
 
 final class HomeViewModel: ObservableObject {
     
+    //MARK: Properties
+    
+    // Updated
+    @Published var userData: HomeDataDTO
+    @Published var isLoginRedirectNeed: Bool = false    // activated when data load fails: logout & redirect to loginView
+    @Published var isViewModelReady: Bool = false       // activated when data complete: progress to homeView
+    
+    // Legacy
     @Published var userName: String = ""
     @Published var myChallenges: [MyChallengeDTO] = []
     @Published var challengeArray: [ChallengeObject] = []
-    @Published var statistics: StatChallengeDTO?
+    @Published var statistics: StatChallengeDTO = StatChallengeDTO()
     
     private let identifier: String
     private var cancellables = Set<AnyCancellable>()
-    lazy var homeService = HomeService(with: self.identifier)
-    
+    private let homeSC: HomeService
+
+    //MARK: Initialize
+
+    @MainActor
     init() {
+        // UserDefault: Load Data
         if let userDefault = UserDefaultManager.loadWith(key: UserDefaultKey.user.rawValue),
-           let identifier = userDefault.identifier {
+           let identifier = userDefault.identifier,
+           let userName = userDefault.userName {
             self.identifier = identifier
+            self.userName = userName
+            
+        // UserDefault: Exception Handling
         } else {
+            print("[HomeViewModel] ViewModel Initialize Failed")
             self.identifier = "unknown"
-            print("[HomeViewModel] Initialize Failed")
+            self.isLoginRedirectNeed = true
         }
+        
+        // Initialize Properties with Identifier
+        self.homeSC = HomeService(with: self.identifier)
+        self.userData = HomeDataDTO()
+        
+        self.prepareData()
         self.addSubscribers()
-        self.loadData()
     }
 
-    private func loadData() {
+    private func prepareData() {
         Task {
-            await self.getUserName()
-            await self.configureData()
-        }
-    }
-    
-    @MainActor
-    private func getUserName() {
-        if let userDefault = UserDefaultManager.loadWith(key: UserDefaultKey.user.rawValue),
-           let userName = userDefault.userName {
-            self.userName = userName
-        } else {
-            self.userName = "unknown"
-            print("[HomeViewModel] UserDefault Data load Failed")
-        }
-    }
-    
-    func configureData() async {
-        do {
-            try await homeService.readyService()
-        } catch let error {
-            print("[HomeViewModel] Failed to Initialize Service: \(error.localizedDescription)")
+            do {
+                try await homeSC.prepareService()
+                self.userData = homeSC.dto
+                self.isViewModelReady = true
+                print("[HomeViewModel] Successfully prepare viewModel")
+                
+            } catch {
+                print("[HomeViewModel] Failed to Initialize HomeService: \(error.localizedDescription)")
+                self.isLoginRedirectNeed = true
+            }
         }
     }
 }
 
-// MARK: Challenge
-
+// MARK: Data Change Detector
+// TODO: Need To Update with using 'userData' version
 extension HomeViewModel {
     
     private func addSubscribers() {
         
-        homeService.challenge.$myChallenges
+        homeSC.challengeSC.$myChallenges
             .receive(on: DispatchQueue.main)
             .sink { [weak self] myChallenges in
                 self?.myChallenges = myChallenges
             }
             .store(in: &cancellables)
         
-        homeService.challenge.$statDTO
+        homeSC.challengeSC.$statDTO
             .sink { [weak self] statistics in
                 self?.statistics = statistics
             }
             .store(in: &cancellables)
         
-        homeService.challenge.$challengeArray
+        homeSC.challengeSC.$challengeArray
             .sink { [weak self] challengeArray in
                 self?.challengeArray = challengeArray
             }
@@ -88,7 +99,7 @@ extension HomeViewModel {
     func tryChallenge(with challengeId: Int) {
         do {
             print(challengeId)
-            try homeService.challenge.setMyChallenges(with: challengeId)
+            try homeSC.challengeSC.setMyChallenges(with: challengeId)
         } catch let error {
             // Handle the error here
             print("[HomeViewModel] Failed to Set Challenge: \(error.localizedDescription)")
@@ -97,7 +108,7 @@ extension HomeViewModel {
     
     func quitChallenge(with challengeId: Int) {
         do {
-            try homeService.challenge.disableMyChallenge(with: challengeId)
+            try homeSC.challengeSC.disableMyChallenge(with: challengeId)
         } catch let error {
             // Handle the error here
             print("[HomeViewModel] Failed to Disable Challenge: \(error.localizedDescription)")

--- a/teamplan/Sources/Views/Home/HomeView.swift
+++ b/teamplan/Sources/Views/Home/HomeView.swift
@@ -11,6 +11,8 @@ import KeychainSwift
 
 struct HomeView: View {
     
+    //MARK: Properties
+    
     private let challengeCardsExample: [ChallengeCardModel] = [
         ChallengeCardModel(image: "applelogo", title: "목표달성의 쾌감!", description: "물방울 3개 모으기"),
         ChallengeCardModel(image: "applelogo", title: "프로젝트 완주", description: "프로젝트 한개 완주"),
@@ -31,48 +33,43 @@ struct HomeView: View {
     @State private var pageControlCount = 1
     @State private var isLoading = false
     
+    @State private var showLogoutAlert = false
+    
+    //MARK: Main
+
     var body: some View {
         NavigationStack {
             ZStack {
-                VStack {
-                    Spacer()
-                        .frame(height: 21)
-                    navigationArea
-                        .padding(.horizontal, 30)
-                        .padding(.bottom, 5)
-                    
-                    ScrollView {
-                        guideArea
-                        
-                        userNameArea
-                            .padding(.top, 40)
-
-                        if isExistProject {
-                            myProjectCardView
-                                .padding(.horizontal, 16)
-                        } else {
-                            noProjectView
-                                .padding(.horizontal, 16)
-                        }
-                            
-                        pageControl
-                            .padding(.top, 12)
-                        
-                        myChallengeArea
-                            .padding(.top, 20)
-                        
-                        challengeCardsArea
-
-                        Spacer()
-                    }
-
-                }
-                .fullScreenCover(isPresented: $showingTutorial) {
-                    TutorialView()
-                }
-                
-                if isLoading {
+                if !homeViewModel.isViewModelReady {
                     LoadingView()
+                } else {
+                    VStack {
+                        Spacer()
+                            .frame(height: 21)
+                        navigationArea
+                            .padding(.horizontal, 30)
+                            .padding(.bottom, 5)
+                        
+                        ScrollView {
+                            guideArea
+                            userNameArea
+                                .padding(.top, 40)
+                            
+                            MyProjectView(isProjectExist: $isExistProject)
+                                .environmentObject(homeViewModel)
+                            
+                            pageControl
+                                .padding(.top, 12)
+                            
+                            MyChallengeView(isChallengeViewActive: $isChallengesViewActive)
+                                .environmentObject(homeViewModel)
+
+                            Spacer()
+                        }
+                    }
+                    .fullScreenCover(isPresented: $showingTutorial) {
+                        TutorialView()
+                    }
                 }
             }
         }
@@ -80,23 +77,47 @@ struct HomeView: View {
             isExistProject = false
             pageControlCount = max(homeViewModel.myChallenges.count, 1)
             Task {
-                await homeViewModel.configureData()
-                isChallenging = !homeViewModel.myChallenges.isEmpty
+                isChallenging = !homeViewModel.userData.myChallenges.isEmpty
+                isExistProject = !homeViewModel.userData.projects.isEmpty
             }
         }
-        .onChange(of: homeViewModel.myChallenges) { newValue in
+        // MyChallege Array Check
+        .onChange(of: homeViewModel.userData.myChallenges) { newValue in
             isChallenging = !homeViewModel.myChallenges.isEmpty
         }
-    }
-}
 
-struct HomeView_Previews: PreviewProvider {
-    static var previews: some View {
-        HomeView()
+        // HomeViewModel Exception Handling
+        .onChange(of: homeViewModel.isLoginRedirectNeed) { newValue in
+            if newValue {
+                LoginService().logoutUser()
+                mainViewState = .login
+            }
+        }
+        .alert(isPresented: $showLogoutAlert) {
+            Alert(
+                title: Text("로그아웃"),
+                message: Text("정말 로그아웃 하시겠습니까?"),
+                primaryButton: .destructive(Text("로그아웃")){
+                    logout()
+                },
+                secondaryButton: .cancel(Text("취소"))
+            )
+        }
+    }
+    
+    //MARK: Function
+    
+    private func logout() {
+        LoginService().logoutUser()
+        withAnimation(.easeIn(duration: 5)) {
+            mainViewState = .login
+        }
     }
 }
 
 extension HomeView {
+    
+    //MARK: Navi: Area
     private var navigationArea: some View {
         HStack {
             Image("title_home")
@@ -105,245 +126,136 @@ extension HomeView {
             Spacer()
             
             Button {
-                let service = LoginService()
-                service.logoutUser()
-                withAnimation(.easeIn(duration: 10)) {
-                    mainViewState = .login
-                }
+                showLogoutAlert = true
             } label: {
                 Text("로그아웃")
             }
-
+            
             NavigationLink(destination: NotificationView(), isActive: $isNotificationViewActive) {
                 Image(systemName: "bell")
                     .foregroundColor(.black)
             }
         }
+        .padding(.horizontal, 16)
     }
     
+    //MARK: Guide: Area
     private var guideArea: some View {
         VStack {
-            HStack {
-                VStack(alignment: .leading) {
-                    Text("투두팡 사용법")
-                        .font(.appleSDGothicNeo(.bold, size: 16))
-                        .foregroundColor(.theme.mainPurpleColor)
-                    Text("투두팡 사용이 어려우신가요? 핵심만 정리된 가이드북 읽어보세요 !")
-                        .font(.appleSDGothicNeo(.regular, size: 12))
-                        .foregroundColor(.theme.blackColor)
-                }
-                .padding(.horizontal, 14)
-                Spacer()
-
-            }
-            .padding(.top, 15)
+            guideTitle
             Spacer()
             ZStack {
-                VStack {
-                    Spacer()
-                        .frame(width: 390, height: 42)
-                        .background(Color.clear)
-                    Rectangle()
-                        .foregroundColor(.clear)
-                        .frame(width: 390, height: 6)
-                        .background(
-                            LinearGradient(
-                                stops: [
-                                    Gradient.Stop(color: Color(red: 0.64, green: 0.6, blue: 0.83).opacity(0.7), location: 0.00),
-                                    Gradient.Stop(color: Color(red: 0.61, green: 0.9, blue: 1).opacity(0.7), location: 1.00),
-                                ],
-                                startPoint: UnitPoint(x: 0, y: 1),
-                                endPoint: UnitPoint(x: 1, y: 1)
-                            )
-                        )
-                }
-                .frame(height: 48)
-                .overlay {
-                    HStack {
-                        Image("bomb")
-                        Spacer()
-                        HStack {
-                            NavigationLink(destination: GuideView(), isActive: $isGuideViewActive) {
-                                Text("읽으러 가기")
-                            }
-                                .font(.appleSDGothicNeo(.bold, size: 12))
-                                .foregroundColor(.theme.whiteColor)
-                                .padding(.trailing, -6)
-                            Image("chevron_right")
-                                .frame(width: 14, height: 12)
-                        }
-                        .foregroundColor(.clear)
-                        .frame(width: 111, height: 28)
-                        .background(Color.theme.mainPurpleColor)
-                        .cornerRadius(16)
-                        .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
-                        .padding(.trailing, -7)
-                        .padding(.bottom, 10)
-                        .onTapGesture {
-//                            showingTutorial.toggle()
-                        }
-
-                        Image("waterdrop_side")
-                    }
-                }
-
-
+                guideBackground
+                guideOverlay
             }
         }
         .frame(height: 120)
         .background(Color(red: 0.92, green: 0.91, blue: 0.95))
+        .padding(.horizontal, 16)
     }
     
-    private var userNameArea: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                Text("\(homeViewModel.userName)" + "님,    ")
-                    .font(.appleSDGothicNeo(.bold, size: 20))
+    //MARK: Guide: Title
+    private var guideTitle: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text("투두팡 사용법")
+                    .font(.appleSDGothicNeo(.bold, size: 16))
+                    .foregroundColor(.theme.mainPurpleColor)
+                Text("투두팡 사용이 어려우신가요? 핵심만 정리된 가이드북 읽어보세요 !")
+                    .font(.appleSDGothicNeo(.regular, size: 12))
                     .foregroundColor(.theme.blackColor)
-                    .background(
-                        Color.init(hex: "7248E1").opacity(0.5)
-                            .frame(height: 3) // underline's height
-                            .offset(y: 7) // underline's y pos
-                    )
-                Spacer()
             }
-            HStack {
-                Text("오늘도 목표를 향해 달려볼까요?")
-                    .font(.appleSDGothicNeo(.bold, size: 20))
-                    .foregroundColor(.theme.blackColor)
-                Spacer()
-            }
+            .padding(.horizontal, 14)
+            Spacer()
         }
-        .padding(.leading, 16)
+        .padding(.top, 15)
     }
     
-    private var noProjectView: some View {
+    //MARK: Guide: Background
+    private var guideBackground: some View {
         VStack {
-            Image("warning_circle")
-                .frame(width: 32, height: 32)
-                .padding(.bottom, 5)
-            Text("프로젝트를 먼저 생성해주세요")
-                .font(.appleSDGothicNeo(.regular, size: 16))
-                .padding(.bottom, 22)
-            Text("프로젝트 생성하기")
-                .font(.appleSDGothicNeo(.semiBold, size: 12))
-                .foregroundColor(.theme.whiteColor)
+            Spacer()
+                .frame(width: 390, height: 42)
+                .background(Color.clear)
+            Rectangle()
+                .foregroundColor(.clear)
+                .frame(width: 390, height: 6)
+                .background(
+                    LinearGradient(
+                        stops: [
+                            Gradient.Stop(color: Color(red: 0.64, green: 0.6, blue: 0.83).opacity(0.7), location: 0.00),
+                            Gradient.Stop(color: Color(red: 0.61, green: 0.9, blue: 1).opacity(0.7), location: 1.00),
+                        ],
+                        startPoint: UnitPoint(x: 0, y: 1),
+                        endPoint: UnitPoint(x: 1, y: 1)
+                    )
+                )
+        }
+        .frame(height: 48)
+    }
+    
+    //MARK: Guide: Overlay
+    private var guideOverlay: some View {
+        HStack {
+            Image("bomb")
+            Spacer()
+            HStack {
+                NavigationLink(destination: GuideView(), isActive: $isGuideViewActive) {
+                    Text("읽으러 가기")
+                        .font(.appleSDGothicNeo(.bold, size: 12))
+                        .foregroundColor(.theme.whiteColor)
+                        .padding(.trailing, -6)
+                    Image("chevron_right")
+                        .frame(width: 14, height: 12)
+                }
                 .frame(width: 111, height: 28)
                 .background(Color.theme.mainPurpleColor)
-                .cornerRadius(4)
-                .onTapGesture {
-                    print("프로젝트 생성하기 클릭")
-                }
-        }
-        .frame(height: 176)
-        .frame(maxWidth: .infinity)
-        .clipped()
-        .background(
-            Rectangle()
-              .foregroundColor(.clear)
-              .frame(width: 358, height: 176)
-              .background(.white)
-              .cornerRadius(8)
-              .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
-        )
-    }
-    
-    private var myProjectCardView: some View {
-        VStack {
-            VStack {
-                HStack {
-                    Text("마감기한이 다가오고 있어요!")
-                        .foregroundColor(.theme.mainPurpleColor)
-                        .font(.appleSDGothicNeo(.regular, size: 12))
-                    Spacer()
-                }
-                
-                HStack {
-                    Text("프로젝트 1")
-                        .font(.appleSDGothicNeo(.bold, size: 18))
-                        .foregroundColor(.black)
-                    Spacer()
-                    HStack {
-                        Image("waterdrop")
-                            .frame(width: 18, height: 14)
-                        Text("10")
-                            .font(.appleSDGothicNeo(.semiBold, size: 18))
-                        Text("개")
-                            .font(.appleSDGothicNeo(.regular, size: 12))
-                            .padding(.leading, -5)
-                    }
-                }
-                
-                HStack {
-                    Text("총 3개의 TODO가 남아있어요")
-                        .font(.appleSDGothicNeo(.regular, size: 12))
-                        .foregroundColor(.black)
-                    Spacer()
-                }
-                
-                Spacer()
-                    .frame(height: 35)
-                
-                // 프로그레스 바
-                let width = UIScreen.main.bounds.width - 16 - 16 - 17 - 17
-                ZStack(alignment: .leading) {
-                    
-                    ZStack(alignment: .trailing) {
-                        Capsule()
-                            .fill(.black.opacity(0.08))
-                            .frame(width: width, height: 8)
-                    }
-                    ZStack {
-                        HStack {
-                            Capsule()
-                                .fill(Color.theme.mainPurpleColor)
-                                .frame(width: calPercent(), height: 8)
-                            Image("bomb_smile")
-                                .padding(.leading, -12)
-                        }
-                    }
-                }
-                .frame(height: 10)
-                
-                HStack {
-                    Text("START")
-                        .font(.appleSDGothicNeo(.regular, size: 12))
-                        .foregroundColor(.theme.greyColor)
-                    Spacer()
-                    Text("D-10")
-                        .font(.appleSDGothicNeo(.regular, size: 12))
-                        .foregroundColor(.theme.blackColor)
-                }
-                Spacer()
-                    .frame(height: 10)
-                
-                HStack {
-                    Spacer()
-                    HStack {
-                        Text("23.02.20")
-                        Text("-")
-                        Text("23.08.23")
-                    }
-                    .font(.appleSDGothicNeo(.regular, size: 12))
-                    .foregroundColor(.gray)
-                }
+                .cornerRadius(16)
+                .shadow(color: .black.opacity(0.05), radius: 5)
+                .padding(.trailing, -7)
+                .padding(.bottom, 10)
+                Image("waterdrop_side")
             }
-            .padding(.horizontal, 17)
-            
         }
-        .frame(height: 176)
-        .frame(maxWidth: .infinity)
-        .clipped()
-        .background(
-            Rectangle()
-              .foregroundColor(.clear)
-              .frame(width: 358, height: 176)
-              .background(.white)
-              .cornerRadius(8)
-              .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
-        )
     }
     
+    //MARK: userName: Area
+    private var userNameArea: some View {
+        VStack(alignment: .leading) {
+            userNameSection
+            pharseSection
+        }
+        .padding(.leading, 16)
+        .padding(.horizontal, 16)
+    }
+    
+    //MARK: userName: Name
+    private var userNameSection: some View {
+        HStack {
+            Text("\(homeViewModel.userName)" + "님,")
+                .font(.appleSDGothicNeo(.bold, size: 20))
+                .foregroundColor(.theme.blackColor)
+                .background(
+                    Color.init(hex: "7248E1").opacity(0.5)
+                        .frame(height: 3) // underline's height
+                        .offset(y: 7) // underline's y pos
+                )
+            Spacer()
+        }
+    }
+    
+    //MARK: userName: pharse
+    private var pharseSection: some View {
+        HStack {
+            Text("\(homeViewModel.userData.phrase)")
+                .font(.appleSDGothicNeo(.bold, size: 20))
+                .foregroundColor(.theme.blackColor)
+            Spacer()
+        }
+    }
+    
+    //MARK: Page Control
+
     private var pageControl: some View {
         HStack(spacing: 4) {
             ForEach(0..<pageControlCount, id: \.self) { index in
@@ -353,98 +265,13 @@ extension HomeView {
             }
         }
         .frame(height: 6)
-    }
-    
-    private var myChallengeArea: some View {
-        HStack {
-            Text("나의 도전과제")
-                .font(.appleSDGothicNeo(.semiBold, size: 20))
-            
-            Spacer()
-            
-            HStack {
-                NavigationLink(destination: ChallengesView(
-                    homeViewModel: homeViewModel),
-                               isActive: $isChallengesViewActive) {
-                    Text("전체보기")
-                }
-                Image("right_arrow_home")
-                    .frame(width: 15, height: 15)
-                    .padding(.leading, -5)
-                    .padding(.bottom, 2)
-            }
-            .font(.appleSDGothicNeo(.regular, size: 12))
-            .onTapGesture {
-                
-            }
-        }
         .padding(.horizontal, 16)
     }
-    
-    private var challengeCardsArea: some View {
-        ZStack {
-            HStack(spacing: 17) {
-                
-                ForEach(0..<$homeViewModel.myChallenges.count, id: \.self) { index in
-                    let challenge = self.$homeViewModel.myChallenges[index]
-                    let screenWidth = UIScreen.main.bounds.size.width
-                    ZStack {
-                        ChallengeCardFrontView(challenge: challenge.wrappedValue, parentsWidth: screenWidth)
-                            .background(.white)
-                            .cornerRadius(4)
-                    }
-                }
-                
-                if $homeViewModel.myChallenges.count < 3 {
-                    // 나머지 뷰를 채우는 코드
-                    ForEach($homeViewModel.myChallenges.count..<3, id: \.self) { index in
-                        // 다른 뷰 표시 (여기서는 기본 Text를 사용하겠습니다.)
-                        ChallengeEmptyView()
-                            .background(.white)
-                            .cornerRadius(4)
-                    }
-                }
-            }
-            .padding(.leading, 16)
-            .padding(.trailing, 16)
-            .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
+}
 
-            
-            VStack {
-                HStack {
-                    Image("waterdrop_reverse")
-                    Spacer()
-                    Image("waterdrop")
-                }
-                .padding(.horizontal, 60)
-                Text("도전과제에 도전하여 물방울을 모아보세요!")
-                    .font(.appleSDGothicNeo(.regular, size: 16))
-                    .foregroundColor(Color(hex: "3B3B3B"))
-                Text("도전하기")
-                    .font(.appleSDGothicNeo(.semiBold, size: 12))
-                    .foregroundColor(.white)
-                    .frame(width: 70, height: 28)
-                    .background(Color(red: 0.51, green: 0.87, blue: 1))
-                    .cornerRadius(4)
-                    .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
-                    .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                    .inset(by: 0.5)
-                    .stroke(Color(red: 0.51, green: 0.87, blue: 1), lineWidth: 1)
-                    )
-                    
-            }
-            .frame(maxWidth: .infinity, maxHeight: 144)
-            .background(.white.opacity(0.8))
-            .cornerRadius(8)
-            .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
-            .opacity(isChallenging ? 0 : 1)
-        }
-    }
-    
-    private func calPercent() -> CGFloat {
-        let width = UIScreen.main.bounds.width - 18 - 18
-        return width * percent
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
     }
 }
 

--- a/teamplan/Sources/Views/Home/SubView/MyChallengeView.swift
+++ b/teamplan/Sources/Views/Home/SubView/MyChallengeView.swift
@@ -1,0 +1,127 @@
+//
+//  MyChallengeView.swift
+//  teamplan
+//
+//  Created by 크로스벨 on 5/20/24.
+//  Copyright © 2024 team1os. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct MyChallengeView: View {
+    
+    //MARK: Properties & Body
+    @EnvironmentObject private var homeVM: HomeViewModel
+    @Binding var isChallengeViewActive: Bool
+    
+    var body: some View {
+        VStack {
+            challengeLinkSection
+                .padding(.top, 20)
+                .padding(.horizontal, 16)
+            myChallengeSection
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    //MARK: Total Challenge Link
+    private var challengeLinkSection: some View {
+        HStack {
+            Text("나의 도전과제")
+                .font(.appleSDGothicNeo(.semiBold, size: 20))
+            Spacer()
+            
+            NavigationLink(
+                destination: ChallengesView(homeViewModel: homeVM),
+                isActive: $isChallengeViewActive)
+            {
+                Text("전체보기")
+            }
+            Image("right_arrow_home")
+                .frame(width: 15, height: 15)
+                .padding(.leading, -5)
+                .padding(.bottom, 2)
+        }
+        .font(.appleSDGothicNeo(.regular, size: 12))
+    }
+    
+    //MARK: ChallengeCard Section
+    private var myChallengeSection: some View {
+        ZStack {
+            checkMyChallenges
+            
+            if homeVM.userData.myChallenges.isEmpty {
+                noMyChallenges
+            }
+        }
+    }
+    
+    //MARK: Extract MyChallenge
+    private var checkMyChallenges: some View {
+        HStack(spacing: 17) {
+            let screenWidth = UIScreen.main.bounds.size.width
+            let myChallengeCount = homeVM.userData.myChallenges.count
+
+            ForEach(0..<3, id: \.self) { index in
+                if index < myChallengeCount {
+                    let challenge = homeVM.userData.myChallenges[index]
+                    ZStack {
+                        ChallengeCardFrontView(challenge: challenge, parentsWidth: screenWidth)
+                            .background(.white)
+                            .cornerRadius(4)
+                    }
+                } else {
+                    ChallengeEmptyView()
+                        .background(.white)
+                        .cornerRadius(4)
+                }
+            }
+        }
+        .padding(.leading, 16)
+        .padding(.trailing, 16)
+        .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
+    }
+    
+    //MARK: No MyChallenge Case
+    private var noMyChallenges: some View {
+        VStack {
+            HStack {
+                Image("waterdrop_reverse")
+                Spacer()
+                Image("waterdrop")
+            }
+            .padding(.horizontal, 60)
+            
+            Text("도전과제에 도전하여 물방울을 모아보세요!")
+                .font(.appleSDGothicNeo(.regular, size: 16))
+                .foregroundColor(Color(hex: "3B3B3B"))
+            
+            Text("도전하기")
+                .font(.appleSDGothicNeo(.semiBold, size: 12))
+                .foregroundColor(.white)
+                .frame(width: 70, height: 28)
+                .background(Color(red: 0.51, green: 0.87, blue: 1))
+                .cornerRadius(4)
+                .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
+                .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                .inset(by: 0.5)
+                .stroke(Color(red: 0.51, green: 0.87, blue: 1), lineWidth: 1)
+                )
+                
+        }
+        .frame(maxWidth: .infinity, maxHeight: 144)
+        .background(.white.opacity(0.8))
+        .cornerRadius(8)
+        .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
+    }
+}
+
+//MARK: Preview
+
+struct MyChallengeView_Previews: PreviewProvider {
+    static var previews: some View {
+        MyChallengeView(isChallengeViewActive: .constant(false))
+    }
+}

--- a/teamplan/Sources/Views/Home/SubView/MyProjectView.swift
+++ b/teamplan/Sources/Views/Home/SubView/MyProjectView.swift
@@ -1,0 +1,227 @@
+//
+//  MyProjectView.swift
+//  teamplan
+//
+//  Created by 크로스벨 on 5/20/24.
+//  Copyright © 2024 team1os. All rights reserved.
+//
+
+import SwiftUI
+
+struct MyProjectView: View {
+    
+    //MARK: Properties & Body
+    @Binding var isProjectExist: Bool
+    @State private var percent: CGFloat = 0.65
+    @EnvironmentObject private var homeVM: HomeViewModel
+    
+    var body: some View {
+        VStack{
+            if isProjectExist {
+                projectList
+                    .padding(.horizontal, 16)
+            } else {
+                noProject
+                    .padding(.horizontal, 16)
+            }
+        }
+    }
+    
+    //MARK: Project Not Registed Bind
+    private var noProject: some View {
+        VStack {
+            Image("warning_circle")
+                .frame(width: 32, height: 32)
+                .padding(.bottom, 5)
+            Text("프로젝트를 먼저 생성해주세요")
+                .font(.appleSDGothicNeo(.regular, size: 16))
+                .padding(.bottom, 22)
+            Text("프로젝트 생성하기")
+                .font(.appleSDGothicNeo(.semiBold, size: 12))
+                .foregroundColor(.theme.whiteColor)
+                .frame(width: 111, height: 28)
+                .background(Color.theme.mainPurpleColor)
+                .cornerRadius(4)
+                .onTapGesture {
+                    print("프로젝트 생성하기 클릭")
+                }
+        }
+        .frame(height: 176)
+        .frame(maxWidth: .infinity)
+        .clipped()
+        .background(
+            Rectangle()
+              .foregroundColor(.clear)
+              .frame(width: 358, height: 176)
+              .background(.white)
+              .cornerRadius(8)
+              .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
+        )
+    }
+    
+    //MARK: Project List & CardView
+    private var projectList: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 16) {
+                ForEach(0..<3, id: \.self) { index in
+                    let project = homeVM.userData.projects[index]
+                    MyProjectCardView(stat: homeVM.statistics, project: project)
+                        .frame(width: UIScreen.main.bounds.width - 32)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+}
+
+struct MyProjectCardView: View {
+    let stat: StatChallengeDTO
+    let project: ProjectHomeDTO
+    let percent: CGFloat = 0.65
+    
+    var body: some View {
+        VStack {
+            projectHead
+            projectTitle
+            projectTodoCount
+            Spacer().frame(height: 35)
+            projectProgressBar
+                .padding(.horizontal, 16)
+            projectDeadline
+        }
+        .frame(height: 176)
+        .frame(maxWidth: .infinity)
+        .clipped()
+        .background(
+            Rectangle()
+                .foregroundColor(.clear)
+                .frame(width: 358, height: 176)
+                .background(.white)
+                .cornerRadius(8)
+                .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 0)
+        )
+        .padding(.horizontal, 16)
+    }
+    
+    //MARK: Head
+    
+    private var projectHead: some  View {
+        HStack {
+            Text("마감기한이 다가오고 있어요!")
+                .foregroundColor(.theme.mainPurpleColor)
+                .font(.appleSDGothicNeo(.regular, size: 12))
+            Spacer()
+        }
+    }
+    
+    //MARK: Title
+    
+    private var projectTitle: some View {
+        HStack {
+            Text("\(project.title)")
+                .font(.appleSDGothicNeo(.bold, size: 18))
+                .foregroundColor(.black)
+            Spacer()
+            projectWaterCount
+        }
+    }
+    
+    //MARK: WaterDrop
+    
+    private var projectWaterCount: some View {
+        HStack {
+            Image("waterdrop")
+                .frame(width: 18, height: 14)
+            Text("\(stat.drop)")
+                .font(.appleSDGothicNeo(.semiBold, size: 18))
+            Text("개")
+                .font(.appleSDGothicNeo(.regular, size: 12))
+                .padding(.leading, -5)
+        }
+    }
+    
+    //MARK: Todo Count
+    
+    private var projectTodoCount: some View {
+        HStack {
+            Text("총 \(project.remainTodo)개의 TODO가 남아있어요")
+                .font(.appleSDGothicNeo(.regular, size: 12))
+                .foregroundColor(.black)
+            Spacer()
+        }
+    }
+    
+    //MARK: Progress Bar
+    /// ios 제공하는 기본 ProgressBar 사용으로 대체하였습니다.
+    /// ProgressView 는 주어진 값 (calcPercent()에 의해 계산된 값)과 총 값 (1.0)을 사용하여 진행 상태를 표시합니다.
+    ///  ProgressView의 스타일은 기존 둥근형태와 폭탄 아이콘 사용을 위해 CustomProgressViewStyle 을 사용합니다.
+    private var projectProgressBar: some View {
+        ProgressView(value: calcPercent(), total: 1.0)
+            .frame(height: 10)
+            .progressViewStyle(CustomProgressViewStyle())
+    }
+    
+    private func calcPercent() -> CGFloat {
+        let progress = CGFloat(project.progressedTerm) / CGFloat(project.totalTerm)
+        return min(max(progress, 0), 1)
+    }
+    
+    //MARK: DeadLine
+    
+    private var projectDeadline: some View {
+        VStack {
+            HStack {
+                Text("START")
+                    .font(.appleSDGothicNeo(.regular, size: 12))
+                    .foregroundColor(.theme.greyColor)
+                Spacer()
+                Text("D-\(project.remainDay)")
+                    .font(.appleSDGothicNeo(.regular, size: 12))
+                    .foregroundColor(.theme.blackColor)
+            }
+            Spacer().frame(height: 10)
+            HStack {
+                Spacer()
+                Text("\(DateFormatter.shortFormatter.string(from: project.startedAt)) - \(DateFormatter.shortFormatter.string(from: project.deadline))")
+                    .font(.appleSDGothicNeo(.regular, size: 12))
+                    .foregroundColor(.gray)
+            }
+        }
+    }
+}
+
+// MARK: Progress Bar Style
+/// ProgressView의 스타일을 커스터마이징하는 구조체입니다.
+/// 기존 코드를 활용하여 배경과 진행바의 색깔과 크기 위치를 설정하였습니다.
+/// 기존의 폭탄 아이콘도 상태진행에 따라 끝부분에서 움직이도록 설정하였습니다.
+struct CustomProgressViewStyle: ProgressViewStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                
+                // Default Background
+                Capsule()
+                    .fill(Color.black.opacity(0.08))
+                    .frame(height: 8)
+                
+                // Progress Background
+                Capsule()
+                    .fill(Color.theme.mainPurpleColor)
+                    .frame(width: geometry.size.width * CGFloat(configuration.fractionCompleted ?? 0), height: 8)
+                
+                // Trail Icon
+                if let fractionCompleted = configuration.fractionCompleted {
+                    Image("bomb_smile")
+                        .offset(x: geometry.size.width * CGFloat(fractionCompleted) - 12)
+                }
+            }
+        }
+    }
+}
+
+
+struct MyProjectView_Previews: PreviewProvider {
+    static var previews: some View {
+        MyProjectView(isProjectExist: .constant(false))
+    }
+}


### PR DESCRIPTION

## Key Changes
* **Service**
  - Data Binding 
    * 기존의 함수별로 객체를 반환하는 방식에서, HomeDataDTO 라는 객체에 모든 데이터를 담고, 해당 객체를 공유하는 방식으로 변경 
    * 이에 prepareService는 단순, Service 동작에 필요한 파라미터 load가 아닌, DTO 객체에 필요 데이터를 채우는 기능으로 변경
    * async/await 비동기 방식으로 모든 데이터의 안전한 load 보장
    * 각 데이터 Load 함수들도 실패한 경우 thorw가 아닌 print를 활용한 에러 출력 및 더미값 return 으로 앱서비스 강제종료 예방

* **ViewModel**
  - Data Binding
     * Service의 변경으로, viewModel 준비기능인 'prepareData()'의 기능변경
     * 새로운 State 변수 도입으로 모든 데이터의 Load가 완료될때까지 HomeView 로딩제어
     * HomeViewModel 데이터가 제대로 Load 되지않는경우, 다른 서비스도 사용이 불가능하기에 로그아웃 & 로그인화면으로 리다이렉트
 
* **View**
  - Divide
    * 각 Area를 기능별로 나누는 작업 수행
    * 프로젝트 관리와 도전과제 관리는 별도의 View파일 생성 및 SubView 그룹으로 이동
    * 구분이후, 가장자리로 에셋들이 쏠리는 현상발생, 이를 해결하기 위해 추가적인 .padding 사용
  - MyProjectView
    * 기존의 더미 데이터로 보여지는 것을 사용자 등록데이터로 변경
    * HomeViewModel를 상속받아 저장된 DTO 객체를 활용
    * ProgressBar 의 경우, iOS에서 제공하는 'ProgressView' 로 변경
    * 관련하여 자세한 내용은 코드 주석확인
  - MyChallengeView
    * 나의 도전과제 추출과정 리팩토링
    * 상속받은 HomeViewModel 내 DTO 객체정보에서 추출하여 사용하는 방식으로 변경
 
* **ETC**
  - Utilities
    * 정확한 날짜계산을 위해 시간대를 강제로 통일하는 코드추가
  - Etc
    * 함수명 변경에 따른 코드수정
  
## To Reviewers
시간 괜찮으실때 내용 확인 부탁드립니다 :)