### PR TITLE
[refeat] Add 'HomeDataDTO' update logic at 'HomeViewModel'

### DIFF
--- a/teamplan/Sources/Services/ChallengeService.swift
+++ b/teamplan/Sources/Services/ChallengeService.swift
@@ -18,12 +18,9 @@ final class ChallengeService {
     private var challengeIdSet = Set<Int>()
     
     // shared
-    @Published var statDTO: StatChallengeDTO
+    @Published var statDTO: StatDTO
     @Published var myChallenges: [MyChallengeDTO] = []
     @Published var challengesDTO: [ChallengeDTO] = []
-    
-    // Legacy
-    @Published var challengeArray: [ChallengeObject] = []
     
     /// `ChallengeService` 클래스의 인스턴스를 초기화합니다.
     ///
@@ -35,13 +32,13 @@ final class ChallengeService {
     /// 이 과정은 앱 내에서 도전과제 기능을 수행하기 위한 기본 설정을 제공합니다.
     init(with userId: String) {
         self.userId = userId        
-        self.statDTO = StatChallengeDTO()
+        self.statDTO = StatDTO()
     }
 }
 
 
-
 // MARK: - Prepare Service
+
 extension ChallengeService {
 
     // main executor
@@ -54,13 +51,10 @@ extension ChallengeService {
             tempDict[challenge.challengeId] = challenge
         }
         challengeDict = tempDict
-        statDTO = StatChallengeDTO(with: try statCD.getObject(with: userId))
+        statDTO = StatDTO(with: try statCD.getObject(with: userId))
         
         try await prepareChallenges()
         try await prepareMyChallenges()
-        
-        // legacy: must be replace to 'challengesDTO'
-        self.challengeArray = challenges
     }
     
     // myChallenges
@@ -141,7 +135,7 @@ extension ChallengeService {
     /// - Throws: 중복 도전과제, 최대 도전과제 수 초과 등으로 인한 오류를 던집니다.
     /// - 이 함수는 중복 검사를 수행하고, 도전과제를 'myChallenges'에 추가하며, 해당 도전과제의 상태를 업데이트합니다.
     /// - 또한 관련 통계 정보를 갱신하고, 모든 변경 사항을 로그로 출력합니다.
-    func setMyChallenges(with challengeId: Int) throws {
+    func setMyChallenges(with challengeId: Int) async throws {
         
         if canAppendMyChallenge(with: challengeId) {
             // properties
@@ -192,7 +186,7 @@ extension ChallengeService {
     /// - Throws: 도전과제 해제 및 상태 업데이트에서 발생한 오류들을 던집니다.
     /// - 이 함수는 도전과제를 'myChallenges'에 제거하며, 해당 도전과제의 상태를 업데이트합니다.
     /// - 또한 관련 통계 정보를 갱신하고, 모든 변경 사항을 로그로 출력합니다.
-    func disableMyChallenge(with challengeId: Int) throws {
+    func disableMyChallenge(with challengeId: Int) async throws {
         // properties
         let updatedAt = Date()
         
@@ -485,29 +479,6 @@ struct MyChallengeDTO: Hashable, Identifiable {
         self.desc = object.desc
         self.goal = object.goal
         self.progress = object.progress
-    }
-}
-
-
-// MARK: - StatChallengeDTO
-struct StatChallengeDTO {
-    
-    let userId: String
-    var drop: Int
-    var challengeStepStatus: [Int : Int]
-    var myChallenges: [Int]
-    
-    init(){
-        self.userId = ""
-        self.drop = 0
-        self.challengeStepStatus = [ : ]
-        self.myChallenges = []
-    }
-    init(with object: StatisticsObject){
-        self.userId = object.userId
-        self.drop = object.drop
-        self.challengeStepStatus = object.challengeStepStatus
-        self.myChallenges = object.mychallenges
     }
 }
 

--- a/teamplan/Sources/Services/HomeService.swift
+++ b/teamplan/Sources/Services/HomeService.swift
@@ -13,6 +13,8 @@ final class HomeService {
     //MARK: Properties
     // private
     private let userId: String
+    private let userName: String
+    
     private let userCD: UserServicesCoredata
     private let statCD: StatisticsServicesCoredata
     private let projectCD: ProjectServicesCoredata
@@ -22,13 +24,14 @@ final class HomeService {
     @Published var dto: HomeDataDTO = HomeDataDTO()
     
     // MARK: - Initializer
-    init(with userId: String) {
-            self.userId = userId
-            self.userCD = UserServicesCoredata()
-            self.statCD = StatisticsServicesCoredata()
-            self.projectCD = ProjectServicesCoredata()
-            self.challengeSC = ChallengeService(with: userId)
-        }
+    init(with userId: String, and userName: String) {
+        self.userId = userId
+        self.userName = userName
+        self.userCD = UserServicesCoredata()
+        self.statCD = StatisticsServicesCoredata()
+        self.projectCD = ProjectServicesCoredata()
+        self.challengeSC = ChallengeService(with: userId)
+    }
     
     // MARK: - PrepareDTO
     func prepareService() async throws {
@@ -42,7 +45,7 @@ final class HomeService {
             async let projeccts = getProjectDTO()
             
             self.dto = try await HomeDataDTO(
-                userName: self.userId,
+                userName: userName,
                 phrase: phrase,
                 statData: statData,
                 challenges: challenges,
@@ -75,13 +78,13 @@ final class HomeService {
     
     // MARK: - Statistics
     
-    private func getStat() async throws -> StatChallengeDTO {
+    func getStat() async throws -> StatDTO {
         do {
             let stat = try statCD.getObject(with: userId)
-            return StatChallengeDTO(with: stat)
+            return StatDTO(with: stat)
         } catch {
             print("[HomeService] Failed to get StatData: \(error.localizedDescription)")
-            return StatChallengeDTO()
+            return StatDTO()
         }
     }
     
@@ -130,7 +133,7 @@ struct HomeDataDTO {
     let id = UUID().uuidString
     let userName: String
     let phrase: String
-    let statData: StatChallengeDTO
+    var statData: StatDTO
     var challenges: [ChallengeDTO]
     var myChallenges: [MyChallengeDTO]
     var projects: [ProjectHomeDTO]
@@ -138,7 +141,7 @@ struct HomeDataDTO {
     init(){
         self.userName = "unknown"
         self.phrase = "unknown"
-        self.statData = StatChallengeDTO()
+        self.statData = StatDTO()
         self.challenges = []
         self.myChallenges = []
         self.projects = []
@@ -146,7 +149,7 @@ struct HomeDataDTO {
     
     init(userName: String,
          phrase: String,
-         statData: StatChallengeDTO,
+         statData: StatDTO,
          challenges: [ChallengeDTO],
          myChallenges: [MyChallengeDTO],
          projects: [ProjectHomeDTO]

--- a/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
+++ b/teamplan/Sources/Services/Statistics/StatisticsServicesCoredata.swift
@@ -214,3 +214,52 @@ extension StatisticsServicesCoredata {
         return isUpdated
     }
 }
+
+//MARK: DTO
+// MARK: - StatChallengeDTO
+struct StatDTO {
+    
+    let userId: String
+    var term: Int
+    var drop: Int
+    var totalRegistedProjects: Int
+    var totalFinishedProjects: Int
+    var totalFailedProjects: Int
+    var totalAlertedProjects: Int
+    var totalExtendedProjects: Int
+    var totalRegistedTodos: Int
+    var totalFinishedTodos: Int
+    var challengeStepStatus: [Int : Int]
+    var myChallenges: [Int]
+    
+    init(){
+        self.userId = ""
+        self.term = 0
+        self.drop = 0
+        self.totalRegistedProjects = 0
+        self.totalFinishedProjects = 0
+        self.totalFailedProjects = 0
+        self.totalAlertedProjects = 0
+        self.totalExtendedProjects = 0
+        self.totalRegistedTodos = 0
+        self.totalFinishedTodos = 0
+        self.challengeStepStatus = [ : ]
+        self.myChallenges = []
+    }
+    
+    init(with object: StatisticsObject){
+        self.userId = object.userId
+        self.term = object.term
+        self.drop = object.drop
+        self.totalRegistedProjects = object.totalRegistedProjects
+        self.totalFinishedProjects = object.totalFinishedProjects
+        self.totalFailedProjects = object.totalFailedProjects
+        self.totalAlertedProjects = object.totalAlertedProjects
+        self.totalExtendedProjects = object.totalExtendedProjects
+        self.totalRegistedTodos = object.totalRegistedTodos
+        self.totalFinishedTodos = object.totalFinishedTodos
+        self.challengeStepStatus = object.challengeStepStatus
+        self.myChallenges = object.mychallenges
+    }
+}
+

--- a/teamplan/Sources/Views/Home/SubView/MyProjectView.swift
+++ b/teamplan/Sources/Views/Home/SubView/MyProjectView.swift
@@ -75,7 +75,7 @@ struct MyProjectView: View {
 }
 
 struct MyProjectCardView: View {
-    let stat: StatChallengeDTO
+    let stat: StatDTO
     let project: ProjectHomeDTO
     let percent: CGFloat = 0.65
     


### PR DESCRIPTION
## Key Changes
1. **‘HomeViewModel’ 업데이트**

	•	‘tryChallenge’ & ‘quitChallenge’ 함수 변경사항
	•	함수 호출 시 userData를 실시간으로 업데이트하는 기능을 추가했습니다.
	•	set 및 disable 동작 시, userData에 실시간으로 적용되도록 로직을 추가했습니다.

2. **‘userData’ 내 statDTO 객체 업데이트**

	•	`기존 도전과제 완료 방식`
	•	ChallengeObject 객체의 progress 수치와 goal 수치를 비교하여 도전과제를 완료했습니다.
	•	문제점: 다른 View에서 도전과제 관련 작업 후, 모든 도전과제 정보를 다시 생성해야 했습니다.
	•	이는 ‘ChallengeView’의 .onAppear 동작 시 100개에 가까운 ChallengeDTO 데이터를 재생성하는 비효율을 발생시켰습니다.

	•	`신규 도전과제 완료 방식`
	•	기존 statChallengeDTO 객체에 progress 정보를 추가했습니다.
	•	‘ChallengeView’의 .onAppear 동작 시 userData.statDTO 객체만 업데이트합니다.
	•	‘HomeViewModel’의 getChallengeProgress 함수를 통해 도전과제의 progress 수치를 반환합니다.
	•	기존 ChallengeObject의 goal 수치와 반환된 progress 값을 비교하여 도전과제를 완료할 수 있도록 했습니다.

3. **기타**
	•	코드의 안정성을 위해 기존 ChallengeObject의 progress 변수는 유지할 예정입니다.


## To Reviewers

> 추가 필요 작업 사항

도전과제와 관련하여 아래의 작업이 추가적으로 필요합니다!

1.	**도전과제 완료 기능 활성화**

	•	ChallengeBackView 확인 시, 포기하기 기능은 활성화되어 있으나 도전과제 완료 기능은 포함되어 있지 않습니다.
	•	목표 수치(ChallengeDTO.goal)와 사용자의 진행도(homeViewModel.getChallengeProgress(with: .ChallengeType))를 비교하는 완료 기능이 필요합니다.
	•	목표 완료 시, Pigma '서비스 Flow' 페이지 내 폭탄맨 캐릭터가 포함된 ‘보상받기 팝업’이 등장해야 합니다.

2.	**‘포기하기’ 진행 시 팝업 에셋 변경 필요**

	•	현재 나오는 포기하기 에셋은 전체 도전과제에서 도전 중인 도전과제 클릭 시 나오는 에셋입니다.
	•	‘포기하기’ 진행 시, Pigma '서비스 Flow' 페이지 내 폭탄맨 캐릭터가 포함된 ‘보상받기 팝업’이 등장해야 합니다.

3.	**전체 도전과제 버튼 아이콘 변경 필요**  `(아이콘 형태) & (ChallengeDTO 수치값)`

	•	나의 도전과제로 **등록된** 아이콘 `(배경: 흰색 / 아이콘: 그레이) & (lock: false / selectStatus: true)`
	•	나의 도전과제로 **등록 가능한** 아이콘 `(배경: 그레이 / 아이콘: 흰색) & (lock: false / selectStatus: false)`
	•	**잠겨진** 도전과제 아이콘 `(배경: 흰색 / 아이콘: 자물쇠) & (lock: true)`
	•	**완료된** 도전과제 아이콘 `(배경: 흰색 / 아이콘: 컬러) & (status: true)`
