### PR TITLE
[debug] About Challenge Related

### DIFF
--- a/teamplan/Info.plist
+++ b/teamplan/Info.plist
@@ -52,6 +52,8 @@
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
+    <key>UIUserInterfaceStyle</key>
+    <string>Light</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen.storyboard</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/teamplan/Sources/Services/ChallengeService.swift
+++ b/teamplan/Sources/Services/ChallengeService.swift
@@ -13,12 +13,12 @@ final class ChallengeService {
     
     // shared
     var rewardDTO: ChallengeRewardDTO
-    @Published var myChallenges: [MyChallengeDTO] = []
-    @Published var challengesDTO: [ChallengeDTO] = []
+    var myChallenges: [MyChallengeDTO] = []
+    var challengesDTO: [ChallengeDTO] = []
     
     // private
-    private let statCD = StatisticsServicesCoredata()
-    private let challengeCD = ChallengeServicesCoredata()
+    private let statCD: StatisticsServicesCoredata
+    private let challengeCD: ChallengeServicesCoredata
     private let localStorageManager: LocalStorageManager
     
     private var userId: String
@@ -27,6 +27,7 @@ final class ChallengeService {
     private var challengeData: ChallengeObject
     private var challengeList: [Int : ChallengeObject] = [:]
     private var isFianlChallenge: Bool = false
+    private var previousDate: Date
     
     init(with userId: String) {
         self.userId = userId        
@@ -34,19 +35,20 @@ final class ChallengeService {
         self.rewardDTO = ChallengeRewardDTO()
         self.challengeDTOIndex = 0
         self.challengeData = ChallengeObject()
+        self.previousDate = Date()
+        
+        self.statCD = StatisticsServicesCoredata()
+        self.challengeCD = ChallengeServicesCoredata()
         self.localStorageManager = LocalStorageManager.shared
     }
 }
 
-// MARK: - Prepare Data
-
 extension ChallengeService {
 
     // Executor
-    func prepareExecutor() -> Bool {
+    func prepareExecutor() async -> Bool {
         let context = localStorageManager.context
         var fetchResults = [Bool]()
-        var prepareResults = [Bool]()
         
         context.performAndWait {
             fetchResults = [
@@ -54,21 +56,23 @@ extension ChallengeService {
                 fetchChallengeObject(with: context)
             ]
         }
-        
-        if fetchResults.allSatisfy({ $0 }) {
-            prepareResults = [
-                prepareMyChallengeDTO(),
-                prepareChallengeDTO()
-            ]
-        } else {
-            print("[ChallengeService] Failed to fetch data")
+        guard fetchResults.allSatisfy({ $0 }) else {
+            print("[ChallengeSC] Failed to fetch data")
             return false
         }
         
-        let isSuccess = prepareResults.allSatisfy { $0 }
-        print("[ChallengeService] \(isSuccess ? "Successfully" : "Failed to") prepare service")
-        return isSuccess
+        async let isMyChallengeReady = prepareMyChallengeDTO()
+        async let isChallengeListReady = prepareChallengeDTO()
+        let prepareResult = await [isMyChallengeReady, isChallengeListReady]
+        
+        guard prepareResult.allSatisfy({$0}) else {
+            print("[ChallengeSC] Failed to preprocessing data")
+            return false
+        }
+        return true
     }
+    
+    // MARK: - Prepare Data
     
     // fetch: Statistics
     private func fetchStatObject(with context: NSManagedObjectContext) -> Bool {
@@ -105,37 +109,35 @@ extension ChallengeService {
     }
     
     // prepare: MyChallenge
-    private func prepareMyChallengeDTO() -> Bool {
+    private func prepareMyChallengeDTO() async -> Bool {
         
         if statDTO.myChallenges.isEmpty {
             self.myChallenges = []
             return true
         }
-        print("[ChallengeService] statData myChallenge: \(statDTO.myChallenges)")
         
         var challengeList = [MyChallengeDTO]()
         for index in statDTO.myChallenges {
             guard let challenge = self.challengeList[index] else {
-                print("[ChallengeService] Error detected while search myChallenge data")
+                print("[ChallengeService] Failed to detected myChallenge: \(index)")
                 return false
             }
-            challengeList.append(MyChallengeDTO(with: challenge))
-        
+            let progress = getUserProgress(with: challenge.type)
+            challengeList.append(MyChallengeDTO(object: challenge, progress: progress))
         }
-        print("[ChallengeService] challengeList: \(challengeList)")
         self.myChallenges = challengeList.sorted{ $0.selectedAt < $1.selectedAt }
         return true
     }
     
-    // prepare: ChallengeDTOs
-    private func prepareChallengeDTO() -> Bool {
+    // prepare: Total Challenges
+    private func prepareChallengeDTO() async -> Bool {
         
         for challenge in challengeList.values {
             if challenge.step == 1 {
                 self.challengesDTO.append(mapFirstStepChallenge(with: challenge))
             } else {
                 guard let previous = self.challengeList[challenge.challengeId - 1] else {
-                    print("[ChallengeService] Failed to search previous challengeData")
+                    print("[ChallengeService] Failed to detected previous challengeData: \(challenge.challengeId - 1)")
                     return false
                 }
                 self.challengesDTO.append(mapOtherStepChallenges(with: challenge, and: previous))
@@ -185,174 +187,190 @@ extension ChallengeService {
 
 extension ChallengeService {
     
-    /// 특정 도전과제를 '나의 도전과제'로 등록합니다.
-    /// - Parameter challengeId: '나의 도전과제'에 등록할 도전과제의 ID입니다.
-    /// - Throws: 중복 도전과제, 최대 도전과제 수 초과 등으로 인한 오류를 던집니다.
-    /// - 이 함수는 중복 검사를 수행하고, 도전과제를 'myChallenges'에 추가하며, 해당 도전과제의 상태를 업데이트합니다.
-    /// - 또한 관련 통계 정보를 갱신하고, 모든 변경 사항을 로그로 출력합니다.
-    func setMyChallenges(with challengeId: Int) -> Bool {
-    
+    // Main
+    func setMyChallenges(with challengeId: Int) async -> Bool {
+        
         // inspection
         if !canAppendMyChallenge(with: challengeId) {
             print("[ChallengeService] Can't regist anymore myChallenges")
             return false
         }
         
-        // extract data
-        if !getChallengeDataFromList(with: challengeId) || !getChallengeIndexFromDTOs(with: challengeId) {
+        // prepare storage & local properties
+        async let isDataFetched = fetchDataFromList(with: challengeId)
+        async let isIndexFetched = fetchIndexFromArray(with: challengeId)
+        let results = await [isDataFetched, isIndexFetched]
+        
+        guard results.allSatisfy({$0}) else {
             print("[ChallengeService] Unknown ChallengeId Detected")
             return false
         }
-        
         let updatedAt = Date()
-        let context = localStorageManager.context
         
+        // update process
+        let context = localStorageManager.context
         return context.performAndWait {
-            // update dto
-            updateDTOAboutSet(with: challengeId)
             
-           // update object
+            // update storage
             let results = [
-                updateStatObjectAboutSet(with: context),
-                updateChallengeObjectAboutSet(with: context, and: challengeId, at: updatedAt)
+                updateStatObjectAboutSet(context, with: challengeId),
+                updateChallengeObjectAboutSet(context, with: challengeId, at: updatedAt)
             ]
-            
-            // apply storage
-            if results.allSatisfy({ $0 }) {
-                if localStorageManager.saveContext() {
-                    print("[ChallengeService] Successfully set new mychallenge at context")
-                    return true
-                } else {
-                    print("[ChallengeService] Failed to set new mychallenge at context")
-                    return false
-                }
-            } else {
-                print("[ChallengeService] Failed to update objects")
+            guard results.allSatisfy({ $0 }) else {
+                print("[ChallengeService] Failed to update objects about set newChallenge")
                 return false
             }
+            
+            // update context
+            guard localStorageManager.saveContext() else {
+                print("[ChallengeService] Failed to update context about set newMyChallenge")
+                return false
+            }
+            
+            // update local
+            let progress = getUserProgress(with: self.challengeData.type)
+            updateDTOAboutSet(with: challengeId, and: self.challengeData, also: progress)
+            return true
         }
     }
     
+    // Util
     private func canAppendMyChallenge(with challengeId: Int) -> Bool {
         return myChallenges.count < 3 &&
         statDTO.myChallenges.count < 3 &&
         !myChallenges.contains(where: { $0.challengeID == challengeId })
     }
     
-    private func updateDTOAboutSet(with challengeId: Int) {
-            
-        self.statDTO.myChallenges.append(challengeId)
-        self.myChallenges.append(MyChallengeDTO(with: self.challengeData))
-        self.challengesDTO[self.challengeDTOIndex].isSelected = true
-    }
-    
-    private func updateChallengeObjectAboutSet(with context: NSManagedObjectContext, and challengeId: Int, at updatedAt: Date) -> Bool {
+    // Storage Upate
+    private func updateChallengeObjectAboutSet(_ context: NSManagedObjectContext, with challengeId: Int, at updatedAt: Date) -> Bool {
+        let userProgress = getUserProgress(with: challengeData.type)
         
-        var updated = ChallengeUpdateDTO(challengeId: challengeId, userId: userId)
-        let userProgress = getUserProgress(with: self.challengeData.type)
-        
-        updated.newProgress = userProgress
-        updated.newSelectStatus = true
-        updated.newSelectedAt = updatedAt
-        
+        let updated = ChallengeUpdateDTO(
+            challengeId: challengeId,
+            userId: userId,
+            newProgress: userProgress,
+            newSelectStatus: true,
+            newSelectedAt: updatedAt
+        )
         do {
             return try challengeCD.updateObject(context: context, dto: updated)
         } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
+            print("[ChallengeSC] Failed to detected challenge entity: \(error.localizedDescription)")
             return false
         }
     }
     
-    private func updateStatObjectAboutSet(with context: NSManagedObjectContext) -> Bool {
+    // Storage Upate
+    private func updateStatObjectAboutSet(_ context: NSManagedObjectContext, with challengeId: Int) -> Bool {
+        var newMyChallenges = statDTO.myChallenges
+        newMyChallenges.append(challengeId)
+        
+        let updated = StatUpdateDTO(
+            userId: userId,
+            newMyChallenges: newMyChallenges
+        )
         do {
-            let newMyChallenges = self.statDTO.myChallenges
-            let updated = StatUpdateDTO(userId: userId, newMyChallenges: newMyChallenges)
             return try statCD.updateObject(context: context, dto: updated)
         } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
+            print("[ChallengeSC] Failed to detected stat entity: \(error.localizedDescription)")
             return false
         }
     }
     
-    // MARK: - Disable myChallenge
+    // Local Upate
+    private func updateDTOAboutSet(with challengeId: Int, and object: ChallengeObject, also progress: Int) {
+        self.statDTO.myChallenges.append(challengeId)
+        self.myChallenges.append(MyChallengeDTO(object: object, progress: progress))
+        self.challengesDTO[challengeDTOIndex].isSelected = true
+    }
+}
+
+// MARK: - Disable myChallenge
+
+extension ChallengeService {
     
-    /// '나의 도전과제'로 등록된 특정 도전과제를 해제합니다.
-    /// - Parameter challengeId: '나의 도전과제'에서 해제할 도전과제의 ID입니다.
-    /// - Throws: 도전과제 해제 및 상태 업데이트에서 발생한 오류들을 던집니다.
-    /// - 이 함수는 도전과제를 'myChallenges'에 제거하며, 해당 도전과제의 상태를 업데이트합니다.
-    /// - 또한 관련 통계 정보를 갱신하고, 모든 변경 사항을 로그로 출력합니다.
-    func disableMyChallenge(with challengeId: Int) -> Bool {
+    // Main
+    func disableMyChallenge(with challengeId: Int) async -> Bool {
         
-        // extract data
-        if !getChallengeDataFromList(with: challengeId) || !getChallengeIndexFromDTOs(with: challengeId) {
+        // prepare storage & local properties
+        async let isDataFetched = fetchDataFromList(with: challengeId)
+        async let isIndexFetched = fetchIndexFromArray(with: challengeId)
+        let results = await [isDataFetched, isIndexFetched]
+        
+        guard results.allSatisfy({$0}) else {
             print("[ChallengeService] Unknown ChallengeId Detected")
             return false
         }
-        
         let updatedAt = Date()
+        
         let context = localStorageManager.context
- 
         return context.performAndWait {
-            // update dto
-            updateDTOAboutDisable(with: challengeId)
             
-           // update object
+            // update object
             let results = [
-                updateStatObjectAboutDisable(with: context),
-                updateChallengeObjectAboutDisable(with: context, and: challengeId, at: updatedAt)
+                updateStatObjectAboutDisable(context, with: challengeId),
+                updateChallengeObjectAboutDisable(context, with: challengeId, at: updatedAt)
             ]
-            
-            // apply storage
-            if results.allSatisfy({ $0 }) {
-                if localStorageManager.saveContext() {
-                    print("[ChallengeService] Successfully saved context")
-                    return true
-                } else {
-                    print("[ChallengeService] Failed to save context")
-                    return false
-                }
-            } else {
-                print("[ChallengeService] Failed to update objects")
+            guard results.allSatisfy({ $0 }) else {
+                print("[ChallengeSC] Failed to update objects about disable myChallenge")
                 return false
             }
+            
+            // update context
+            guard localStorageManager.saveContext() else {
+                print("[ChallengeSC] Failed to update context about disable myChallenge")
+                return false
+            }
+            // update dto
+            updateDTOAboutDisable(with: challengeId)
+            return true
         }
     }
     
-    private func updateDTOAboutDisable(with challengeId: Int) {
-        
-        self.statDTO.myChallenges.removeAll { $0 == challengeId }
-        self.myChallenges.removeAll{ $0.challengeID == challengeId }
-        self.challengesDTO[self.challengeDTOIndex].isSelected = false
-    }
-    
-    private func updateChallengeObjectAboutDisable(with context: NSManagedObjectContext, and challengeId: Int, at updatedAt: Date) -> Bool {
-        
-        var updated = ChallengeUpdateDTO(challengeId: challengeId, userId: userId)
-        
-        updated.newSelectStatus = false
-        updated.newUnSelectedAt = updatedAt
-        
+    // Storage Upate
+    private func updateChallengeObjectAboutDisable(_ context: NSManagedObjectContext, with challengeId: Int, at updatedAt: Date) -> Bool {
+        let updated = ChallengeUpdateDTO(
+            challengeId: challengeId,
+            userId: userId,
+            newSelectStatus: false,
+            newUnSelectedAt: updatedAt
+        )
         do {
             return try challengeCD.updateObject(context: context, dto: updated)
         } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
+            print("[ChallengeSC] Failed to detected challenge data: \(error.localizedDescription)")
             return false
         }
     }
     
-    private func updateStatObjectAboutDisable(with context: NSManagedObjectContext) -> Bool {
+    // Storage Upate
+    private func updateStatObjectAboutDisable(_ context: NSManagedObjectContext, with challengeId: Int) -> Bool {
+        var newMyChallenges = statDTO.myChallenges
+        newMyChallenges.removeAll { $0 == challengeId }
+        
+        let updated = StatUpdateDTO(
+            userId: userId,
+            newMyChallenges: newMyChallenges
+        )
         do {
-            let newMyChallenges = self.statDTO.myChallenges
-            let updated = StatUpdateDTO(userId: userId, newMyChallenges: newMyChallenges)
-            
             return try statCD.updateObject(context: context, dto: updated)
         } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
+            print("[ChallengeSC] Failed to detected stat data: \(error.localizedDescription)")
             return false
         }
     }
     
-    // MARK: - Reward myChallenge
+    // Local Update
+    private func updateDTOAboutDisable(with challengeId: Int) {
+        self.statDTO.myChallenges.removeAll { $0 == challengeId }
+        self.myChallenges.removeAll{ $0.challengeID == challengeId }
+        self.challengesDTO[challengeDTOIndex].isSelected = false
+    }
+}
+
+// MARK: - Reward myChallenge
+
+extension ChallengeService {
 
     /// 완료한 도전과제에 대한 보상을 처리합니다.
     /// - Parameter challengeId: 보상을 받을 도전과제의 ID입니다.
@@ -361,72 +379,188 @@ extension ChallengeService {
     /// - 이 함수는 도전과제 보상을 지급하며, 해당 도전과제와 다음 도전과제의 상태를 업데이트합니다.
     /// - 또한 관련 통계 정보를 갱신하고, '나의 도전과제'에서 해당 도전과제를 해제합니다.
     /// - 모든 변경 사항 및 보상정보를 로그로 출력합니다.
-    func rewardMyChallenge(with challengeId: Int) -> Bool {
+    
+    // Main
+    func rewardMyChallenge(with challengeId: Int) async -> Bool {
         
-        guard getChallengeDataFromList(with: challengeId),
-              getChallengeIndexFromDTOs(with: challengeId),
-              getNextChallengeData(with: self.challengeData) else {
-            print("[ChallengeService] Unknown or invalid ChallengeId Detected")
+        // prepare base data
+        async let isDataFetched = fetchDataFromList(with: challengeId)
+        async let isIndexFetched = fetchIndexFromArray(with: challengeId)
+        let results = await [isDataFetched, isIndexFetched]
+        
+        guard results.allSatisfy({$0}) else {
+            print("[ChallengeService] Invalid ChallengeId Detected")
             return false
         }
-
+        
         let updatedAt = Date()
-        let currentChallengeData = self.challengeData
-        let currentChallengeIndex = self.challengeDTOIndex
+        let currentData = self.challengeData
+        let currentIndex = self.challengeDTOIndex
+        
+        // inspection: step data
+        guard checkNextData(with: self.challengeData) else {
+            print("[ChallengeService] Failed to get next Challenge Data")
+            return false
+        }
         let context = localStorageManager.context
-
+        
+        // divide process
+        if isFianlChallenge {
+            
+            // final: additional data not neccessary
+            return finalChallengeRewardProcess(context, id: challengeId, data: currentData, index: currentIndex, updatedAt: updatedAt)
+            
+        } else {
+            
+            // mid: additional data require
+            let nextId = self.challengeData.challengeId
+            guard await fetchIndexFromArray(with: self.challengeData.challengeId) else {
+                print("[ChallengeService] Invalid nextChallengeId Detected")
+                return false
+            }
+            let nextIndex = self.challengeDTOIndex
+            
+            return midChallengeRewardProcess(context, currentId: challengeId, nextId: nextId, currentData: currentData, currentIndex: currentIndex, nextIndex: nextIndex, updatedAt: updatedAt)
+        }
+    }
+    
+    // Sub
+    private func finalChallengeRewardProcess(_ context: NSManagedObjectContext, id: Int, data: ChallengeObject, index: Int, updatedAt: Date) -> Bool {
+        
+        var results = [Bool]()
         return context.performAndWait {
-            // Update current challenge
-            updateCurrentDTOAboutReward(with: challengeId, and: currentChallengeIndex, at: updatedAt)
-            let updateCurrentResults = [
-                updateCurrentChallengeAboutReward(with: context, with: challengeId, at: updatedAt),
-                updateCurrentStatAboutReward(with: context)
+            
+            // update storage
+            results = [
+                updateCurrentChallengeAboutReward(context, with: id, at: updatedAt),
+                updateCurrentStatAboutReward(context, with: id, and: data)
             ]
-
-            guard updateCurrentResults.allSatisfy({ $0 }) else {
-                print("[ChallengeService] Failed to update current reward objects")
+            guard results.allSatisfy({ $0 }) else {
+                print("[ChallengeService] Failed to update objects about reward myChallenge")
                 return false
             }
-
-            self.rewardDTO = ChallengeRewardDTO(with: currentChallengeData)
-
-            // Update next challenge if not the final challenge
-            if !self.isFianlChallenge {
-                let nextChallenge = self.challengeData
-                let nextChallengeId = nextChallenge.challengeId
-                guard getChallengeIndexFromDTOs(with: nextChallengeId) else {
-                    print("[ChallengeService] Unknown Next ChallengeId Detected")
-                    return false
-                }
-                let nextChallengeIndex = self.challengeDTOIndex
-
-                updateNextDTOAboutReward(with: currentChallengeIndex, and: nextChallengeIndex)
-                let updateNextResults = [
-                    updateNextChallengeAboutReward(with: context, with: nextChallengeId),
-                    updateNextStatAboutReward(with: context)
-                ]
-
-                guard updateNextResults.allSatisfy({ $0 }) else {
-                    print("[ChallengeService] Failed to update next reward objects")
-                    return false
-                }
-                self.rewardDTO = ChallengeRewardDTO(with: currentChallengeData, and: nextChallenge)
-            }
-
+            
+            // update context
             guard localStorageManager.saveContext() else {
-                print("[ChallengeService] Failed to apply localStorage")
+                print("[ChallengeService] Failed to update context about reward myChallenge")
                 return false
             }
+            
+            // update local
+            updateCurrentDTOAboutReward(with: id, and: index, at: updatedAt, and: data.reward)
             return true
         }
     }
     
-    // update current: dto
-    private func updateCurrentDTOAboutReward(with challengeId: Int, and index: Int, at updatedAt: Date) {
+    // Sub
+    private func midChallengeRewardProcess(_ context: NSManagedObjectContext, currentId: Int, nextId: Int, currentData: ChallengeObject, currentIndex: Int, nextIndex: Int, updatedAt: Date) -> Bool {
         
-        self.statDTO.drop += self.challengesDTO[index].reward
-        self.statDTO.myChallenges.removeAll{ $0 == challengeId }
+        var results = [Bool]()
+        return context.performAndWait{
+            
+            // update storage
+            results = [
+                updateCurrentChallengeAboutReward(context, with: currentId, at: updatedAt),
+                updateCurrentStatAboutReward(context, with: currentId, and: currentData),
+                updateNextChallengeAboutReward(context, with: nextId),
+                updateNextStatAboutReward(context, with: currentData.step)
+            ]
+            guard results.allSatisfy({ $0 }) else {
+                print("[ChallengeService] Failed to update objects about reward myChallenge")
+                return false
+            }
+            
+            // update context
+            guard localStorageManager.saveContext() else {
+                print("[ChallengeService] Failed to update context about reward myChallenge")
+                return false
+            }
+            
+            // update local
+            updateCurrentDTOAboutReward(with: currentId, and: currentIndex, at: updatedAt, and: currentData.reward)
+            updateNextDTOAboutReward(with: currentIndex, and: nextIndex, step: currentData.step)
+            return true
+        }
+    }
+    
+    // Update challenge: current
+    private func updateCurrentChallengeAboutReward(_ context: NSManagedObjectContext, with challengeId: Int,at updatedAt: Date) -> Bool {
+        let updated = ChallengeUpdateDTO(
+            challengeId: challengeId,
+            userId: userId,
+            newStatus: true,
+            newSelectStatus: false,
+            newUnSelectedAt: updatedAt,
+            newFinishedAt: updatedAt
+        )
+        do {
+            return try challengeCD.updateObject(context: context, dto: updated)
+        } catch {
+            print("[ChallengeSC] Failed to detected challenge data: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // Update challenge: next
+    private func updateNextChallengeAboutReward(_ context: NSManagedObjectContext, with challengeId: Int) -> Bool {
         
+        let updated = ChallengeUpdateDTO(
+            challengeId: challengeId,
+            userId: userId,
+            newLock: false
+        )
+        do {
+            return try challengeCD.updateObject(context: context, dto: updated)
+        } catch {
+            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // Update stat: current
+    private func updateCurrentStatAboutReward(_ context: NSManagedObjectContext, with challengeId: Int, and challengeData: ChallengeObject) -> Bool {
+        
+        var newMyChallenges = statDTO.myChallenges
+        newMyChallenges.removeAll { $0 == challengeId }
+        let newDrop = statDTO.drop + challengeData.reward
+        
+        let updated = StatUpdateDTO(
+            userId: userId,
+            newDrop: newDrop,
+            newMyChallenges: newMyChallenges
+        )
+        do {
+            return try statCD.updateObject(context: context, dto: updated)
+        } catch {
+            print("[ChallengeService] Failed to detected stat data: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // Update stat: next
+    private func updateNextStatAboutReward(_ context: NSManagedObjectContext, with step: Int) -> Bool {
+        
+        var newStep = statDTO.challengeStepStatus
+        if let currentValue = newStep[step] {
+            newStep[step] = currentValue + 1
+        }
+        let updated = StatUpdateDTO(
+            userId: userId,
+            newChallengeStepStatus: newStep
+        )
+        do {
+            return try statCD.updateObject(context: context, dto: updated)
+        } catch {
+            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // Update local: current
+    private func updateCurrentDTOAboutReward(with challengeId: Int, and index: Int, at updatedAt: Date, and reward: Int) {
+        
+        statDTO.drop += reward
+        statDTO.myChallenges.removeAll{ $0 == challengeId }
         self.myChallenges.removeAll{ $0.challengeID == challengeId }
         
         self.challengesDTO[index].isSelected = false
@@ -434,100 +568,20 @@ extension ChallengeService {
         self.challengesDTO[index].finishedAt = updatedAt
     }
     
-    // update current: object
-    private func updateCurrentChallengeAboutReward(with context: NSManagedObjectContext, with challengeId: Int,at updatedAt: Date) -> Bool {
-        
-        var updated = ChallengeUpdateDTO(challengeId: challengeId, userId: userId)
-        
-        updated.newStatus = true
-        updated.newSelectStatus = false
-        updated.newFinishedAt  = updatedAt
-        
-        do {
-            return try challengeCD.updateObject(context: context, dto: updated)
-        } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
-            return false
-        }
-    }
-    
-    private func updateCurrentStatAboutReward(with context: NSManagedObjectContext) -> Bool {
-        
-        var updated = StatUpdateDTO(userId: userId)
-        
-        updated.newDrop = statDTO.drop
-        updated.newMyChallenges = statDTO.myChallenges
-        
-        do {
-            return try statCD.updateObject(context: context, dto: updated)
-        } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
-            return false
-        }
-    }
-    
-    // update next: dto
-    private func updateNextDTOAboutReward(with currentIndex: Int, and nextIndex: Int) {
+    // Update local: next
+    private func updateNextDTOAboutReward(with currentIndex: Int, and nextIndex: Int, step: Int) {
         
         let currentType = self.challengesDTO[currentIndex].type.rawValue
         
-        self.statDTO.challengeStepStatus[currentType]! += 1
+        if let currentValue = statDTO.challengeStepStatus[step] {
+            statDTO.challengeStepStatus[step] = currentValue + 1
+        }
         self.challengesDTO[nextIndex].islock = true
     }
     
-    // update next: object
-    private func updateNextChallengeAboutReward(with context: NSManagedObjectContext, with challengeId: Int) -> Bool {
+    // Util: check next challenge
+    private func checkNextData(with currentChallenge: ChallengeObject) -> Bool {
         
-        var updated = ChallengeUpdateDTO(challengeId: challengeId, userId: userId)
-        
-        updated.newLock = false
-        
-        do {
-            return try challengeCD.updateObject(context: context, dto: updated)
-        } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
-            return false
-        }
-    }
-    
-    private func updateNextStatAboutReward(with context: NSManagedObjectContext) -> Bool {
-        
-        var updated = StatUpdateDTO(userId: userId)
-        
-        updated.newChallengeStepStatus = statDTO.challengeStepStatus
-        
-        do {
-            return try statCD.updateObject(context: context, dto: updated)
-        } catch {
-            print("[ChallengeService] Error detected while search entity: \(error.localizedDescription)")
-            return false
-        }
-    }
-}
-
-// MARK: Util
-
-extension ChallengeService {
-    
-    private func getChallengeDataFromList(with challengeId: Int) -> Bool {
-        guard let data = challengeList[challengeId] else {
-            print("[ChallengeService] Failed to search ChallengeData at List")
-            return false
-        }
-        self.challengeData = data
-        return true
-    }
-    
-    private func getChallengeIndexFromDTOs(with challengeId: Int) -> Bool {
-        guard let index = challengesDTO.firstIndex(where: { $0.challengeId == challengeId}) else {
-            print("[ChallengeService] Failed to search ChallengeIndex at List")
-            return false
-        }
-        self.challengeDTOIndex = index
-        return true
-    }
-    
-    private func getNextChallengeData(with currentChallenge: ChallengeObject) -> Bool {
         // Final Challenge
         if currentChallenge.step == getChallengeStepLimit(with: currentChallenge.type) {
             print("[ChallengeService] Final challenge step complete")
@@ -547,6 +601,29 @@ extension ChallengeService {
             self.challengeData = ChallengeObject()
             return false
         }
+    }
+}
+
+// MARK: Util
+
+extension ChallengeService {
+    
+    private func fetchDataFromList(with challengeId: Int) async -> Bool {
+        guard let data = challengeList[challengeId] else {
+            print("[ChallengeService] Failed to search ChallengeData at List")
+            return false
+        }
+        self.challengeData = data
+        return true
+    }
+    
+    private func fetchIndexFromArray(with challengeId: Int) async -> Bool {
+        guard let index = challengesDTO.firstIndex(where: { $0.challengeId == challengeId}) else {
+            print("[ChallengeService] Failed to search ChallengeIndex at List")
+            return false
+        }
+        self.challengeDTOIndex = index
+        return true
     }
     
     private func getUserProgress(with type: ChallengeType) -> Int {
@@ -665,13 +742,13 @@ struct MyChallengeDTO: Hashable, Identifiable {
         self.selectedAt = Date()
     }
     
-    init(with object: ChallengeObject){
+    init(object: ChallengeObject, progress: Int){
         self.challengeID = object.challengeId
         self.type = object.type
         self.title = object.title
         self.desc = object.desc
         self.goal = object.goal
-        self.progress = object.progress
+        self.progress = progress
         self.selectedAt = object.selectedAt
     }
 }

--- a/teamplan/Sources/Services/HomeService.swift
+++ b/teamplan/Sources/Services/HomeService.swift
@@ -114,7 +114,7 @@ final class HomeService {
                 if myChallenges.isEmpty {
                     dto.myChallenges = []
                 } else {
-                    dto.myChallenges = myChallenges.map{ MyChallengeDTO(with: $0) }
+                    dto.myChallenges = myChallenges.map{ MyChallengeDTO(object: $0, progress: 0) }
                 }
                 return true
                 

--- a/teamplan/Sources/Util/LocalStorageManager.swift
+++ b/teamplan/Sources/Util/LocalStorageManager.swift
@@ -39,7 +39,6 @@ final class LocalStorageManager {
     
     func saveContext() -> Bool {
         if context.hasChanges {
-            print("[localStorage] Context change detected")
             do {
                 try self.context.save()
                 return true
@@ -49,7 +48,6 @@ final class LocalStorageManager {
                 return false
             }
         }
-        print("[localStorage] Context change not detected")
         return true
     }
     

--- a/teamplan/Sources/ViewModels/HomeViewModel.swift
+++ b/teamplan/Sources/ViewModels/HomeViewModel.swift
@@ -46,10 +46,9 @@ final class HomeViewModel: ObservableObject {
         self.userData = HomeDataDTO(with: userName)
     }
 
-    func prepareData() -> Bool {
-        
+    func prepareData() async -> Bool {
         if self.service.prepareExecutor() {
-            self.userData = service.dto
+            await updateProperties()
             return true
         } else {
             print("[HomeViewModel] Failed to Initialize ViewModel")
@@ -57,9 +56,9 @@ final class HomeViewModel: ObservableObject {
         }
     }
      
-    func updateData() -> Bool {
+    func updateData() async -> Bool {
         if self.service.updateExecutor() {
-            self.userData = service.dto
+            await updateProperties()
             return true
         } else {
             print("[HomeViewModel] Failed to update ViewModel userData")
@@ -67,23 +66,9 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
-    func getChallengeProgress(with type: ChallengeType) -> Int {
-        switch type {
-        case .onboarding:
-            return 0
-        case .serviceTerm:
-            return userData.statData.term
-        case .waterDrop:
-            return userData.statData.drop
-        case .projectAlert:
-            return userData.statData.totalAlertedProjects
-        case .projectFinish:
-            return userData.statData.totalFailedProjects
-        case .totalTodo:
-            return userData.statData.totalRegistedTodos
-        default:
-            return -1
-        }
+   @MainActor
+    private func updateProperties() {
+        self.userData = service.dto
     }
 }
 

--- a/teamplan/Sources/Views/Alert/ChallengeAlertView.swift
+++ b/teamplan/Sources/Views/Alert/ChallengeAlertView.swift
@@ -98,7 +98,7 @@ extension ChallengeAlertView {
                 .foregroundColor(.theme.mainPurpleColor)
     
             
-            Text("\(getChallenge(index: self.index).title)\n이 배찌를 획득하였어요.")
+            Text("\(getChallenge(index: self.index).title) 를 완료하여 \n \(getChallenge(index: self.index).reward) 개의 물방울을 획득했었어요.")
                 .font(.appleSDGothicNeo(.regular, size: 17))
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
@@ -106,7 +106,7 @@ extension ChallengeAlertView {
                 .padding(.top, 12)
                 .padding(.horizontal, 40)
             
-            Text("닫기")
+            Text("보상받기")
                 .frame(maxWidth: .infinity)
                 .frame(height: 44)
                 .font(.appleSDGothicNeo(.bold, size: 14))
@@ -408,7 +408,7 @@ extension ChallengeAlertView {
                 .foregroundColor(.theme.mainPurpleColor)
     
             
-            Text("\(getChallenge(index: self.index).title)\n이 배찌를 획득하였어요.")
+            Text("\(getChallenge(index: self.index).title) 를 완료해서\n\(getChallenge(index: self.index).reward) 개의 물방울을 획득했어요.")
                 .font(.appleSDGothicNeo(.regular, size: 17))
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
@@ -428,6 +428,7 @@ extension ChallengeAlertView {
                 .padding(.vertical, 16)
                 .onTapGesture {
                     self.isPresented = false
+                    action()
                 }
         }
     }

--- a/teamplan/Sources/Views/Challenges/SubViews/ChallengeCardBackView.swift
+++ b/teamplan/Sources/Views/Challenges/SubViews/ChallengeCardBackView.swift
@@ -52,7 +52,7 @@ struct ChallengeCardBackView: View {
     
     private var actionButton: some View {
         Button(action: handleButtonTap) {
-            Text(challenge.progress == challenge.goal ? "완료하기" : "포기하기")
+            Text(challenge.progress >= challenge.goal ? "완료하기" : "포기하기")
                 .frame(maxWidth: .infinity)
                 .frame(height: 25)
                 .background(Color.theme.mainPurpleColor)
@@ -63,7 +63,6 @@ struct ChallengeCardBackView: View {
         .padding(.horizontal, 10)
         .padding(.top, 12)
     }
-    
 }
 
 extension ChallengeCardBackView {
@@ -74,32 +73,22 @@ extension ChallengeCardBackView {
     
     private func calculateProgressBarWidth() -> CGFloat {
         guard challenge.goal != 0 else { return 0 }
-        let progressRatio = CGFloat(challenge.progress) / CGFloat(challenge.goal)
+        let progress = CGFloat(challenge.progress) / CGFloat(challenge.goal)
+        let progressRatio = min(progress, 1.0)
         return progressRatio * (setCardWidth(screenWidth: parentsWidth) - 34)
     }
     
     private func handleButtonTap() {
         Task {
-            if challenge.progress == challenge.goal {
-                await completeChallenge()
+            if challenge.progress >= challenge.goal {
+                // reward challenge
+                self.type = .complete
+                self.isPresented.toggle()
             } else {
-                quitChallenge()
+                // disable challenge
+                self.type = .quit
+                self.isPresented.toggle()
             }
         }
-    }
-    
-    private func completeChallenge() async {
-        if await viewModel.rewardMyChallenge(with: challenge.challengeID) {
-            self.type = .complete
-            self.isPresented.toggle()
-        } else {
-            // 실패 케이스 처리
-            // 예: 에러 메시지 표시
-        }
-    }
-    
-    private func quitChallenge() {
-        self.type = .quit
-        self.isPresented.toggle()
     }
 }

--- a/teamplan/Sources/Views/Home/HomeView.swift
+++ b/teamplan/Sources/Views/Home/HomeView.swift
@@ -61,11 +61,12 @@ struct HomeView: View {
                         TutorialView()
                     }
                     .onAppear {
-                        let isProceed = viewModel.updateData()
-                        if isProceed {
-                            checkProperties()
-                        } else {
-                            showUpdateAlert = true
+                        Task {
+                            if await viewModel.updateData() {
+                                checkProperties()
+                            } else {
+                                showUpdateAlert = true
+                            }
                         }
                     }
                     .alert(isPresented: $showUpdateAlert) {
@@ -75,12 +76,13 @@ struct HomeView: View {
             }
         }
         .onAppear {
-            let isReady = viewModel.prepareData()
-            if isReady {
-                isLoading = false
-            } else {
-                showLoadAlert = true
-                isRedirecting = true
+            Task {
+                if await viewModel.prepareData() {
+                    isLoading = false
+                } else {
+                    showLoadAlert = true
+                    isRedirecting = true
+                }
             }
         }
         .alert(isPresented: $showLoadAlert) {


### PR DESCRIPTION

## Key Changes

### Service
  - 코드 가독성 향상을 위해 if 문을 guard문으로 변경
  - 서비스 안정성을 높이기 위해, Storage 저장이 완료된 경우에만 로컬 변수들에 대한 변경을 진행하도록 변경 
    - 로컬변수는 화면에 최종적으로 보이는 변수와 관련있음
  - '포기하기' 와 '도전하기' 기능 활성화 
    - Service 레이어에 제대로 구현되어있지 않아 코드완성
    - 보상받기의 경우, 마지막 도전과제와 중간 도전과제로 구분하여 코드구성
  - @Published 속성제거
    -  데이터 변경이 잦은 Service 레이어의 변수에 해당 속성 선언은 책임과 역할에 맞지 않다고 보여짐 
    - 이 부분을 보정하기위해 ViewModel 코드수정
### ViewModel
  - addSubscribers 함수 주석화
    - 나의 도전과제와 전체 도전과제의 변경사항 트래킹을 등록하는 'addSubscribers' 함수 주석화
    - 해당 부분은 도전과제에 대한 사용자의 동작 시에만 변경이 필요하다고 판단
    - 이에 이를 대체하는 updateProperties() 함수 추가
    - 자세한 내용은 주석 참조
### View
  - '보상받기' 및 '포기하기' 기능 활성화
    - 기존코드에서는, 해당 부분 동작시 별다른 처리가 이뤄지지 않도록 되어있었음
    - BackCardView 에서 지정된 AlertView를 호출하도록 설정 (포기하기 = .quit / 보상받기 = .complete)
    - 'handleChallengeAlert' 부분에서 각각 해당되는 동작을 ViewModel 에서 호출하도록 코드추가
  - 진행바 수정
    - 'ChallengeCardBackView' 에서 progress 가 goal 보다 큰 경우, 진행바가 공간을 초과하는 문제확인
    -  이에 연산결과가 1.0 비율을 넘으면, 1.0 으로 값을 초기화하는 로직을 추가하여 해결
### ETC
  - Info.plist
    - 서비스 모드가 항상 Light 이도록 지정
  - print
    - 더이상 필요하지 않은 print 구문제거

## To Reviewers

### ChallengeView 및 ChallengeAlertView 관련하여 수정이 필요합니다!

**1. ChallengeAlertView 변경 필요사항**
  * .didSelected
    * 현재 .willChallenge 와 같은 아이콘 타입으로 구성되어있음
    * .didComplete 과 유사하지만, 내부 아이콘이 회색이 아이콘으로 변경필요
  * .quit
    * 현재 .willChallenge 와 같은 아이콘 타입으로 구성되어있음
    * 폭탄맨 등장 AlertView 로 교체필요
  * .complete
    * 현재 .willChallenge 와 같은 아이콘 타입으로 
    * 폭탄맨 등장 AlertView 로 교체필요

**2.  ChallengeGridView**
  * 모든 도전과제를 보여주는 아이콘 중 일부 변경필요
    * 나의 도전과제로 등록한 도전과제의 경우, .didComplete 과 유사하지만, 내부 아이콘이 회색이 아이콘으로 변경필요
    * 이는 나의 도전과제로 등록되었으나, 아직 완료하거나 포기하지 않은 상태를 표시


